### PR TITLE
Add support for incremental snapshots and restores

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,4 +33,4 @@ jobs:
       run: dotnet build --no-restore
       
     - name: Test
-      run: dotnet test --no-build --verbosity normal
+      run: dotnet test --no-build --verbosity normal -m:1

--- a/FileSnap.Core/Models/DirectorySnapshot.cs
+++ b/FileSnap.Core/Models/DirectorySnapshot.cs
@@ -6,6 +6,11 @@
 public class DirectorySnapshot
 {
     /// <summary>
+    /// Gets or sets a value indicating whether the directory has been deleted.
+    /// </summary>
+    public bool IsDeleted { get; set; }
+
+    /// <summary>
     /// Gets or sets the directory path.
     /// </summary>
     public string? Path { get; set; }

--- a/FileSnap.Core/Models/FileSnapshot.cs
+++ b/FileSnap.Core/Models/FileSnapshot.cs
@@ -6,6 +6,11 @@
 public class FileSnapshot
 {
     /// <summary>
+    /// Gets or sets a value indicating whether the file has been deleted.
+    /// </summary>
+    public bool IsDeleted { get; set; }
+
+    /// <summary>
     /// Gets or sets the file path.
     /// </summary>
     public string? Path { get; set; }

--- a/FileSnap.Core/Services/ComparisonService.cs
+++ b/FileSnap.Core/Services/ComparisonService.cs
@@ -58,6 +58,7 @@ public class ComparisonService : IComparisonService
         {
             if (!afterFiles.ContainsKey(beforeFile.Path!))
             {
+                beforeFile.IsDeleted = true;
                 difference.DeletedFiles.Add(beforeFile);
             }
         }
@@ -101,6 +102,7 @@ public class ComparisonService : IComparisonService
 
             if (!afterDirs.ContainsKey(beforeDir.Path))
             {
+                beforeDir.IsDeleted = true;
                 difference.DeletedDirectories.Add(beforeDir);
             }
         }

--- a/FileSnap.Core/Services/ISnapshotService.cs
+++ b/FileSnap.Core/Services/ISnapshotService.cs
@@ -15,6 +15,15 @@ public interface ISnapshotService
     Task<SystemSnapshot> CaptureSnapshotAsync(string path);
 
     /// <summary>
+    /// Captures an incremental snapshot of the file system at the specified path based on the previous snapshot.
+    /// </summary>
+    /// <param name="path">The path to capture the snapshot from.</param>
+    /// <param name="previousSnapshot">The previous snapshot to compare against.</param>
+    /// <returns>A task that represents the asynchronous operation. The task result contains the captured incremental snapshot.</returns>
+    Task<SystemSnapshot> CaptureIncrementalSnapshotAsync(string path, SystemSnapshot previousSnapshot);
+
+
+    /// <summary>
     /// Loads a snapshot from the specified path.
     /// </summary>
     /// <param name="path">The path to load the snapshot from.</param>

--- a/FileSnap.Tests/ComparisonServiceTests.cs
+++ b/FileSnap.Tests/ComparisonServiceTests.cs
@@ -129,6 +129,30 @@ public class ComparisonServiceTests : IDisposable
         Assert.Single(difference.ModifiedDirectories);
     }
 
+    [Fact]
+    public void Compare_ShouldDetectIncrementalChanges()
+    {
+        // Arrange
+        var before = CreateSnapshot();
+        before.RootDirectory!.Files.Add(new FileSnapshot { Path = "file1.txt", Hash = "hash1" });
+        before.RootDirectory!.Files.Add(new FileSnapshot { Path = "file2.txt", Hash = "hash2" });
+        before.RootDirectory!.Directories.Add(new DirectorySnapshot { Path = "dir1" });
+
+        var after = CreateSnapshot();
+        after.RootDirectory!.Files.Add(new FileSnapshot { Path = "file2.txt", Hash = "newhash2" }); // Modified
+        after.RootDirectory!.Files.Add(new FileSnapshot { Path = "file3.txt", Hash = "hash3" }); // New
+        after.RootDirectory!.Directories.Add(new DirectorySnapshot { Path = "dir2" }); // New
+
+        // Act
+        var difference = _comparisonService.Compare(before, after);
+
+        // Assert
+        Assert.Single(difference.NewFiles);
+        Assert.Single(difference.ModifiedFiles);
+        Assert.Single(difference.NewDirectories);
+        Assert.Single(difference.DeletedFiles);
+    }
+
     private static SystemSnapshot CreateSnapshot()
         => new()
         {
@@ -137,8 +161,8 @@ public class ComparisonServiceTests : IDisposable
             RootDirectory = new DirectorySnapshot
             {
                 Path = "basepath",
-                Files = new List<FileSnapshot>(),
-                Directories = new List<DirectorySnapshot>()
+                Files = [],
+                Directories = []
             }
         };
 }

--- a/FileSnap.Tests/RestorationServiceTests.cs
+++ b/FileSnap.Tests/RestorationServiceTests.cs
@@ -1,16 +1,17 @@
-﻿using FileSnap.Core.Models;
-using FileSnap.Core.Services;
-using System.Text;
+﻿using FileSnap.Core.Services;
 
 namespace FileSnap.Tests;
 
 public class RestorationServiceTests : IDisposable
 {
+    private readonly SnapshotService _snapshotService;
     private readonly RestorationService _restorationService;
     private readonly string _testDir;
 
     public RestorationServiceTests()
     {
+        var hashingService = new HashingService();
+        _snapshotService = new SnapshotService(hashingService);
         _restorationService = new RestorationService();
         _testDir = Path.Combine(Path.GetTempPath(), "FileSnapTests_RestorationServiceTests");
         Directory.CreateDirectory(_testDir);
@@ -30,32 +31,38 @@ public class RestorationServiceTests : IDisposable
     public async Task RestoreSnapshot_ShouldRestoreDirectoryStructure()
     {
         // Arrange
-        var snapshot = CreateSnapshot();
+        var dirPath = Path.Combine(_testDir, "DirStructureTest");
+        Directory.CreateDirectory(dirPath);
+        File.WriteAllText(Path.Combine(dirPath, "file1.txt"), "This is a test file.");
+        var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
         var snapshotPath = Path.Combine(_testDir, "snapshot.json");
-        await File.WriteAllBytesAsync(snapshotPath, snapshot.RootDirectory!.Files[0].Content!);
+        await _snapshotService.SaveSnapshotAsync(snapshot, snapshotPath);
 
         // Act
         await _restorationService.RestoreSnapshotAsync(snapshot, _testDir);
 
         // Assert
-        var restoredDir = Path.Combine(_testDir, "test");
+        var restoredDir = Path.Combine(_testDir, "DirStructureTest");
         Assert.True(Directory.Exists(restoredDir));
-        Assert.True(File.Exists(Path.Combine(restoredDir, "test.txt")));
+        Assert.True(File.Exists(Path.Combine(restoredDir, "file1.txt")));
     }
 
     [Fact]
     public async Task RestoreSnapshot_ShouldRestoreFiles()
     {
         // Arrange
-        var snapshot = CreateSnapshot();
+        var dirPath = Path.Combine(_testDir, "FileRestoreTest");
+        Directory.CreateDirectory(dirPath);
+        File.WriteAllText(Path.Combine(dirPath, "file2.txt"), "This is a test file.");
+        var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
         var snapshotPath = Path.Combine(_testDir, "snapshot.json");
-        await File.WriteAllBytesAsync(snapshotPath, snapshot.RootDirectory!.Files[0].Content!);
+        await _snapshotService.SaveSnapshotAsync(snapshot, snapshotPath);
 
         // Act
         await _restorationService.RestoreSnapshotAsync(snapshot, _testDir);
 
         // Assert
-        var restoredFile = Path.Combine(_testDir, "test", "test.txt");
+        var restoredFile = Path.Combine(_testDir, "FileRestoreTest", "file2.txt");
         Assert.True(File.Exists(restoredFile));
         var content = await File.ReadAllTextAsync(restoredFile);
         Assert.Equal("This is a test file.", content);
@@ -65,33 +72,39 @@ public class RestorationServiceTests : IDisposable
     public async Task RestoreSnapshot_ShouldHandleExistingFiles()
     {
         // Arrange
-        var snapshot = CreateSnapshot();
+        var dirPath = Path.Combine(_testDir, "ExistingFilesTest");
+        Directory.CreateDirectory(dirPath);
+        File.WriteAllText(Path.Combine(dirPath, "file3.txt"), "This is a test file.");
+        var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
         var snapshotPath = Path.Combine(_testDir, "snapshot.json");
-        await File.WriteAllBytesAsync(snapshotPath, snapshot.RootDirectory!.Files[0].Content!);
+        await _snapshotService.SaveSnapshotAsync(snapshot, snapshotPath);
 
-        var existingFile = Path.Combine(_testDir, "test", "test.txt");
-        Directory.CreateDirectory(Path.Combine(_testDir, "test"));
-        await File.WriteAllTextAsync(existingFile, "Modified content.");
+        var existingFile = Path.Combine(_testDir, "ExistingFilesTest", "file3.txt");
+        Directory.CreateDirectory(Path.Combine(_testDir, "ExistingFilesTest"));
+        await File.WriteAllTextAsync(existingFile, "Existing content");
 
         // Act
         await _restorationService.RestoreSnapshotAsync(snapshot, _testDir);
 
         // Assert
-        var restoredFile = Path.Combine(_testDir, "test", "test.txt");
+        var restoredFile = Path.Combine(_testDir, "ExistingFilesTest", "file3.txt");
         Assert.True(File.Exists(restoredFile));
         var content = await File.ReadAllTextAsync(restoredFile);
-        Assert.Equal("Modified content.", content);
+        Assert.Equal("This is a test file.", content);
     }
 
     [Fact]
     public async Task RestoreSnapshot_ShouldHandleExistingDirectories()
     {
         // Arrange
-        var snapshot = CreateSnapshot();
+        var dirPath = Path.Combine(_testDir, "ExistingDirsTest");
+        Directory.CreateDirectory(dirPath);
+        File.WriteAllText(Path.Combine(dirPath, "file4.txt"), "This is a test file.");
+        var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
         var snapshotPath = Path.Combine(_testDir, "snapshot.json");
-        await File.WriteAllBytesAsync(snapshotPath, snapshot.RootDirectory!.Files[0].Content!);
+        await _snapshotService.SaveSnapshotAsync(snapshot, snapshotPath);
 
-        var existingDir = Path.Combine(_testDir, "test");
+        var existingDir = Path.Combine(_testDir, "ExistingDirsTest");
         Directory.CreateDirectory(existingDir);
 
         // Act
@@ -99,42 +112,142 @@ public class RestorationServiceTests : IDisposable
 
         // Assert
         Assert.True(Directory.Exists(existingDir));
-        Assert.True(File.Exists(Path.Combine(existingDir, "test.txt")));
+        Assert.True(File.Exists(Path.Combine(existingDir, "file4.txt")));
     }
 
-    private SystemSnapshot CreateSnapshot()
+    [Fact]
+    public async Task RestoreSnapshot_InvalidCreationTime_ShowThrow_ArgumentOutOfRangeException()
     {
-        var content = Encoding.UTF8.GetBytes("This is a test file.");
-        var filePath = Path.Combine(_testDir, "test", "test.txt");
-        Directory.CreateDirectory(Path.GetDirectoryName(filePath)!);
-        File.WriteAllBytes(filePath, content);
+        // Arrange
+        var dirPath = Path.Combine(_testDir, "InvalidCreationTimeTest");
+        Directory.CreateDirectory(dirPath);
+        File.WriteAllText(Path.Combine(dirPath, "file5.txt"), "This is a test file.");
+        var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
+        snapshot.RootDirectory!.Files[0].CreatedAt = DateTime.MinValue; // Invalid creation time
+        var snapshotPath = Path.Combine(_testDir, "snapshot.json");
+        await _snapshotService.SaveSnapshotAsync(snapshot, snapshotPath);
 
-        return new SystemSnapshot
-        {
-            Id = Guid.NewGuid(),
-            BasePath = "basepath",
-            RootDirectory = new DirectorySnapshot
-            {
-                Path = "basepath",
-                Files =
-                [
-                    new() {
-                        Path = "test/test.txt",
-                        Content = content,
-                        Hash = Convert.ToBase64String(content),
-                        CreatedAt = DateTime.Now,
-                        LastModified = DateTime.Now,
-                        Attributes = FileAttributes.Normal,
-                    }
-                ],
-                Directories =
-                [
-                    new DirectorySnapshot
-                    {
-                        Path = "test"
-                    }
-                ]
-            }
-        };
+        // Act
+        await _restorationService.RestoreSnapshotAsync(snapshot, _testDir);
+
+        // Assert
+        var restoredFile = Path.Combine(_testDir, "InvalidCreationTimeTest", "file5.txt");
+        Assert.True(File.Exists(restoredFile));
+        var content = await File.ReadAllTextAsync(restoredFile);
+        Assert.Equal("This is a test file.", content);
+    }
+
+    [Fact]
+    public async Task RestoreSnapshot_ShouldRestoreFileAttributes()
+    {
+        // Arrange
+        var dirPath = Path.Combine(_testDir, "FileAttributesTest");
+        Directory.CreateDirectory(dirPath);
+        var filePath = Path.Combine(dirPath, "file6.txt");
+        File.WriteAllText(filePath, "This is a test file.");
+        File.SetAttributes(filePath, FileAttributes.Temporary);
+        var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
+        var snapshotPath = Path.Combine(_testDir, "snapshot.json");
+        await _snapshotService.SaveSnapshotAsync(snapshot, snapshotPath);
+
+        // Act
+        await _restorationService.RestoreSnapshotAsync(snapshot, _testDir);
+
+        // Assert
+        var restoredFile = Path.Combine(_testDir, "FileAttributesTest", "file6.txt");
+        Assert.True(File.Exists(restoredFile));
+        var attributes = File.GetAttributes(restoredFile);
+        Assert.Equal(FileAttributes.Temporary, attributes);
+    }
+
+    [Fact]
+    public async Task RestoreIncrementalSnapshot_ShouldHandleNewFiles()
+    {
+        // Arrange
+        var dirPath = Path.Combine(_testDir, "IncrementalNewFilesTest");
+        Directory.CreateDirectory(dirPath);
+        File.WriteAllText(Path.Combine(dirPath, "file7.txt"), "This is a test file.");
+        _ = await _snapshotService.CaptureSnapshotAsync(dirPath);
+        var incrementalDirPath = Path.Combine(_testDir, "IncrementalNewFilesTest");
+        File.WriteAllText(Path.Combine(incrementalDirPath, "newfile.txt"), "This is a new file.");
+        var incrementalSnapshot = await _snapshotService.CaptureSnapshotAsync(incrementalDirPath);
+        var snapshotPath = Path.Combine(_testDir, "snapshot.json");
+        await _snapshotService.SaveSnapshotAsync(incrementalSnapshot, snapshotPath);
+
+        // Act
+        await _restorationService.RestoreSnapshotAsync(incrementalSnapshot, _testDir);
+
+        // Assert
+        var newFile = Path.Combine(_testDir, "IncrementalNewFilesTest", "newfile.txt");
+        Assert.True(File.Exists(newFile));
+        var content = await File.ReadAllTextAsync(newFile);
+        Assert.Equal("This is a new file.", content);
+    }
+
+    [Fact]
+    public async Task RestoreIncrementalSnapshot_ShouldHandleDeletedFiles()
+    {
+        // Arrange
+        var dirPath = Path.Combine(_testDir, "IncrementalDeletedFilesTest");
+        Directory.CreateDirectory(dirPath);
+        File.WriteAllText(Path.Combine(dirPath, "file8.txt"), "This is a test file.");
+        _ = await _snapshotService.CaptureSnapshotAsync(dirPath);
+        File.Delete(Path.Combine(dirPath, "file8.txt"));
+        var incrementalSnapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
+        var snapshotPath = Path.Combine(_testDir, "snapshot.json");
+        await _snapshotService.SaveSnapshotAsync(incrementalSnapshot, snapshotPath);
+
+        // Act
+        await _restorationService.RestoreSnapshotAsync(incrementalSnapshot, _testDir);
+
+        // Assert
+        var deletedFile = Path.Combine(_testDir, "IncrementalDeletedFilesTest", "file8.txt");
+        Assert.False(File.Exists(deletedFile));
+    }
+
+    [Fact]
+    public async Task RestoreIncrementalSnapshot_ShouldHandleModifiedFiles()
+    {
+        // Arrange
+        var dirPath = Path.Combine(_testDir, "IncrementalModifiedFilesTest");
+        Directory.CreateDirectory(dirPath);
+        File.WriteAllText(Path.Combine(dirPath, "file9.txt"), "This is a test file.");
+        _ = await _snapshotService.CaptureSnapshotAsync(dirPath);
+        File.WriteAllText(Path.Combine(dirPath, "file9.txt"), "This is a modified file.");
+        var incrementalSnapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
+        var snapshotPath = Path.Combine(_testDir, "snapshot.json");
+        await _snapshotService.SaveSnapshotAsync(incrementalSnapshot, snapshotPath);
+
+        // Act
+        await _restorationService.RestoreSnapshotAsync(incrementalSnapshot, _testDir);
+
+        // Assert
+        var modifiedFile = Path.Combine(_testDir, "IncrementalModifiedFilesTest", "file9.txt");
+        Assert.True(File.Exists(modifiedFile));
+        var content = await File.ReadAllTextAsync(modifiedFile);
+        Assert.Equal("This is a modified file.", content);
+    }
+
+    [Fact]
+    public async Task RestoreIncrementalSnapshot_ShouldHandleDeletedDirectories()
+    {
+        // Arrange
+        var dirPath = Path.Combine(_testDir, "IncrementalDeletedDirsTest");
+        Directory.CreateDirectory(dirPath);
+        var subDirPath = Path.Combine(dirPath, "subdir");
+        Directory.CreateDirectory(subDirPath);
+        File.WriteAllText(Path.Combine(subDirPath, "file10.txt"), "This is a test file.");
+        _ = await _snapshotService.CaptureSnapshotAsync(dirPath);
+        Directory.Delete(subDirPath, true);
+        var incrementalSnapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
+        var snapshotPath = Path.Combine(_testDir, "snapshot.json");
+        await _snapshotService.SaveSnapshotAsync(incrementalSnapshot, snapshotPath);
+
+        // Act
+        await _restorationService.RestoreSnapshotAsync(incrementalSnapshot, _testDir);
+
+        // Assert
+        var deletedDir = Path.Combine(_testDir, "IncrementalDeletedDirsTest", "subdir");
+        Assert.False(Directory.Exists(deletedDir));
     }
 }

--- a/FileSnap.Tests/RestorationServiceTests.cs
+++ b/FileSnap.Tests/RestorationServiceTests.cs
@@ -21,6 +21,11 @@ public class RestorationServiceTests : IDisposable
     {
         if (Directory.Exists(_testDir))
         {
+            foreach (var file in Directory.GetFiles(_testDir))
+            {
+                File.SetAttributes(file, FileAttributes.Normal);
+            }
+
             Directory.Delete(_testDir, true);
         }
 
@@ -145,7 +150,7 @@ public class RestorationServiceTests : IDisposable
         Directory.CreateDirectory(dirPath);
         var filePath = Path.Combine(dirPath, "file6.txt");
         File.WriteAllText(filePath, "This is a test file.");
-        File.SetAttributes(filePath, FileAttributes.Temporary);
+        File.SetAttributes(filePath, FileAttributes.Normal);
         var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
         var snapshotPath = Path.Combine(_testDir, "snapshot.json");
         await _snapshotService.SaveSnapshotAsync(snapshot, snapshotPath);
@@ -157,7 +162,7 @@ public class RestorationServiceTests : IDisposable
         var restoredFile = Path.Combine(_testDir, "FileAttributesTest", "file6.txt");
         Assert.True(File.Exists(restoredFile));
         var attributes = File.GetAttributes(restoredFile);
-        Assert.Equal(FileAttributes.Temporary, attributes);
+        Assert.Equal(FileAttributes.Normal, attributes);
     }
 
     [Fact]

--- a/FileSnap.Tests/SnapshotServiceTests.cs
+++ b/FileSnap.Tests/SnapshotServiceTests.cs
@@ -10,22 +10,22 @@ public class SnapshotServiceTests : IDisposable
 {
     private readonly SnapshotService _snapshotService;
     private readonly SnapshotService _snapshotServiceWithCompression;
-    private readonly string _testBasePath;
+    private readonly string _testDir;
 
     public SnapshotServiceTests()
     {
         var hashingService = new HashingService();
         _snapshotService = new SnapshotService(hashingService);
         _snapshotServiceWithCompression = new SnapshotService(hashingService, true);
-        _testBasePath = Path.Combine(Path.GetTempPath(), "FileSnapTests_" + Guid.NewGuid());
-        Directory.CreateDirectory(_testBasePath);
+        _testDir = Path.Combine(Path.GetTempPath(), "FileSnapTests_SnapshotServiceTests");
+        Directory.CreateDirectory(_testDir);
     }
 
     public void Dispose()
     {
-        if (Directory.Exists(_testBasePath))
+        if (Directory.Exists(_testDir))
         {
-            Directory.Delete(_testBasePath, true);
+            Directory.Delete(_testDir, true);
         }
 
         GC.SuppressFinalize(this);
@@ -35,7 +35,7 @@ public class SnapshotServiceTests : IDisposable
     public async Task CaptureSnapshot_EmptyDirectory_ReturnsValidSnapshot()
     {
         // Arrange
-        var dirPath = Path.Combine(_testBasePath, "EmptyDir");
+        var dirPath = Path.Combine(_testDir, "EmptyDir");
         Directory.CreateDirectory(dirPath);
 
         // Act
@@ -52,7 +52,7 @@ public class SnapshotServiceTests : IDisposable
     public async Task CaptureSnapshot_WithDirectories_ReturnsValidSnapshot()
     {
         // Arrange
-        var dirPath = Path.Combine(_testBasePath, "DirWithDirectories");
+        var dirPath = Path.Combine(_testDir, "DirWithDirectories");
         Directory.CreateDirectory(dirPath);
         Directory.CreateDirectory(Path.Combine(dirPath, "SubDirA"));
         Directory.CreateDirectory(Path.Combine(dirPath, "SubDirB"));
@@ -72,7 +72,7 @@ public class SnapshotServiceTests : IDisposable
     public async Task CaptureSnapshot_WithFiles_ReturnsValidSnapshot()
     {
         // Arrange
-        var dirPath = Path.Combine(_testBasePath, "DirWithFiles");
+        var dirPath = Path.Combine(_testDir, "DirWithFiles");
         Directory.CreateDirectory(dirPath);
         File.WriteAllText(Path.Combine(dirPath, "file1.txt"), "This is a test file.");
         File.WriteAllText(Path.Combine(dirPath, "file2.txt"), "This is another test file.");
@@ -92,7 +92,7 @@ public class SnapshotServiceTests : IDisposable
     public async Task CaptureSnapshot_WithSubDirectories_ReturnsValidSnapshot()
     {
         // Arrange
-        var dirPath = Path.Combine(_testBasePath, "DirWithSubDirs");
+        var dirPath = Path.Combine(_testDir, "DirWithSubDirs");
         Directory.CreateDirectory(dirPath);
         var subDirPath = Path.Combine(dirPath, "SubDir");
         Directory.CreateDirectory(subDirPath);
@@ -114,7 +114,7 @@ public class SnapshotServiceTests : IDisposable
     public async Task CaptureSnapshot_LargeDirectoryStructure_ShouldWorkCorrectly()
     {
         // Arrange
-        var dirPath = Path.Combine(_testBasePath, "LargeDir");
+        var dirPath = Path.Combine(_testDir, "LargeDir");
         Directory.CreateDirectory(dirPath);
         for (int i = 0; i < 100; i++)
         {
@@ -158,10 +158,10 @@ public class SnapshotServiceTests : IDisposable
     public async Task SaveSnapshot_AppendsJsonExtensionIfNotSpecified()
     {
         // Arrange
-        var dirPath = Path.Combine(_testBasePath, "EmptyDir");
+        var dirPath = Path.Combine(_testDir, "EmptyDir");
         Directory.CreateDirectory(dirPath);
         var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
-        var outputPath = Path.Combine(_testBasePath, "snapshot");
+        var outputPath = Path.Combine(_testDir, "snapshot");
 
         // Act
         await _snapshotService.SaveSnapshotAsync(snapshot, outputPath);
@@ -175,10 +175,10 @@ public class SnapshotServiceTests : IDisposable
     public async Task SaveSnapshot_UsesSpecifiedExtension()
     {
         // Arrange
-        var dirPath = Path.Combine(_testBasePath, "EmptyDir");
+        var dirPath = Path.Combine(_testDir, "EmptyDir");
         Directory.CreateDirectory(dirPath);
         var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
-        var outputPath = Path.Combine(_testBasePath, "snapshot.custom");
+        var outputPath = Path.Combine(_testDir, "snapshot.custom");
 
         // Act
         await _snapshotService.SaveSnapshotAsync(snapshot, outputPath);
@@ -191,11 +191,11 @@ public class SnapshotServiceTests : IDisposable
     public async Task SaveAndLoadSnapshot_WithoutCompression_ShouldWorkCorrectly()
     {
         // Arrange
-        var dirPath = Path.Combine(_testBasePath, "DirWithFiles");
+        var dirPath = Path.Combine(_testDir, "DirWithFiles");
         Directory.CreateDirectory(dirPath);
         File.WriteAllText(Path.Combine(dirPath, "file1.txt"), "This is a test file.");
         var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
-        var outputPath = Path.Combine(_testBasePath, "snapshot.json");
+        var outputPath = Path.Combine(_testDir, "snapshot.json");
 
         // Act
         await _snapshotService.SaveSnapshotAsync(snapshot, outputPath);
@@ -214,11 +214,11 @@ public class SnapshotServiceTests : IDisposable
     public async Task SaveAndLoadSnapshot_WithCompressionEnabled_ShouldWorkCorrectly()
     {
         // Arrange
-        var dirPath = Path.Combine(_testBasePath, "DirWithFiles");
+        var dirPath = Path.Combine(_testDir, "DirWithFiles");
         Directory.CreateDirectory(dirPath);
         File.WriteAllText(Path.Combine(dirPath, "file1.txt"), "This is a test file.");
         var snapshot = await _snapshotServiceWithCompression.CaptureSnapshotAsync(dirPath);
-        var outputPath = Path.Combine(_testBasePath, "snapshot.json");
+        var outputPath = Path.Combine(_testDir, "snapshot.json");
 
         // Act
         await _snapshotServiceWithCompression.SaveSnapshotAsync(snapshot, outputPath);
@@ -239,11 +239,11 @@ public class SnapshotServiceTests : IDisposable
         // Arrange
         var customCompressionService = new CustomCompressionService();
         var snapshotServiceWithCustomCompression = new SnapshotService(new HashingService(), true, customCompressionService);
-        var dirPath = Path.Combine(_testBasePath, "DirWithFiles");
+        var dirPath = Path.Combine(_testDir, "DirWithFiles");
         Directory.CreateDirectory(dirPath);
         File.WriteAllText(Path.Combine(dirPath, "file1.txt"), "This is a test file.");
         var snapshot = await snapshotServiceWithCustomCompression.CaptureSnapshotAsync(dirPath);
-        var outputPath = Path.Combine(_testBasePath, "snapshot.json");
+        var outputPath = Path.Combine(_testDir, "snapshot.json");
 
         // Act
         await snapshotServiceWithCustomCompression.SaveSnapshotAsync(snapshot, outputPath);
@@ -262,8 +262,8 @@ public class SnapshotServiceTests : IDisposable
     public async Task SaveAndLoadSnapshot_RoundTrip_PreservesData()
     {
         // Arrange
-        var dirPath = Path.Combine(_testBasePath, "SaveLoad");
-        var outputPath = Path.Combine(_testBasePath, "test.json");
+        var dirPath = Path.Combine(_testDir, "SaveLoad");
+        var outputPath = Path.Combine(_testDir, "test.json");
         CreateTestDirectoryStructure(dirPath, 2, 2);
         var originalSnapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
 
@@ -283,11 +283,74 @@ public class SnapshotServiceTests : IDisposable
     public async Task CaptureSnapshot_DirectoryNotFound_ThrowsException()
     {
         // Arrange
-        var nonExistentPath = Path.Combine(_testBasePath, "NonExistent");
+        var nonExistentPath = Path.Combine(_testDir, "NonExistent");
 
         // Act & Assert
         await Assert.ThrowsAsync<SnapshotException>(() =>
             _snapshotService.CaptureSnapshotAsync(nonExistentPath));
+    }
+
+    [Fact]
+    public async Task CaptureIncrementalSnapshot_ShouldDetectNewFiles()
+    {
+        // Arrange
+        var dirPath = Path.Combine(_testDir, "IncrementalDir");
+        Directory.CreateDirectory(dirPath);
+        var initialSnapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
+
+        // Add new file
+        File.WriteAllText(Path.Combine(dirPath, "newfile.txt"), "This is a new file.");
+
+        // Act
+        var incrementalSnapshot = await _snapshotService.CaptureIncrementalSnapshotAsync(dirPath, initialSnapshot);
+
+        // Assert
+        Assert.Single(incrementalSnapshot.RootDirectory!.Files);
+        Assert.Equal("newfile.txt", Path.GetFileName(incrementalSnapshot.RootDirectory.Files[0].Path));
+    }
+
+    [Fact]
+    public async Task CaptureIncrementalSnapshot_ShouldDetectDeletedFiles()
+    {
+        // Arrange
+        var dirPath = Path.Combine(_testDir, "IncrementalDir");
+        Directory.CreateDirectory(dirPath);
+        var filePath = Path.Combine(dirPath, "file.txt");
+        File.WriteAllText(filePath, "This is a test file.");
+        var initialSnapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
+
+        // Delete file
+        File.Delete(filePath);
+
+        // Act
+        var incrementalSnapshot = await _snapshotService.CaptureIncrementalSnapshotAsync(dirPath, initialSnapshot);
+
+        // Assert
+        Assert.Single(incrementalSnapshot.RootDirectory!.Files);
+        Assert.Equal("file.txt", Path.GetFileName(incrementalSnapshot.RootDirectory.Files[0].Path));
+        Assert.True(incrementalSnapshot.RootDirectory.Files[0].IsDeleted);
+    }
+
+    [Fact]
+    public async Task CaptureIncrementalSnapshot_ShouldDetectModifiedFiles()
+    {
+        // Arrange
+        var dirPath = Path.Combine(_testDir, "IncrementalDir");
+        Directory.CreateDirectory(dirPath);
+        var filePath = Path.Combine(dirPath, "file.txt");
+        File.WriteAllText(filePath, "This is a test file.");
+        var initialSnapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
+
+        // Modify file
+        File.WriteAllText(filePath, "This is a modified file.");
+
+        // Act
+        var incrementalSnapshot = await _snapshotService.CaptureIncrementalSnapshotAsync(dirPath, initialSnapshot);
+
+        // Assert
+        Assert.Single(incrementalSnapshot.RootDirectory!.Files);
+        Assert.Equal("file.txt", Path.GetFileName(incrementalSnapshot.RootDirectory.Files[0].Path));
+        Assert.NotEqual(initialSnapshot.RootDirectory!.Files[0].Hash, incrementalSnapshot.RootDirectory.Files[0].Hash);
     }
 
     private static void CreateTestDirectoryStructure(string basePath, int depth, int breadth)


### PR DESCRIPTION
Fixes #1 

This pull request adds support for incremental snapshots and restores including the following:

- Added a new property `IsDeleted` to the `DirectorySnapshot` and `FileSnapshot` classes.
- Updated the `ComparisonService` to detect and flag deleted files and directories.
- Introduced a new method `CaptureIncrementalSnapshotAsync` in `ISnapshotService` and its implementation in `SnapshotService` to capture incremental snapshots based on a previous snapshot.
- Modified the `RestorationService` to handle the restoration of deleted files and directories.
- Updated the CI workflow to run tests in parallel with the -m:1 flag.
- Added and updated unit tests to verify the new incremental snapshot functionality.
- Updated the README to include documentation on capturing and restoring incremental snapshots.

These changes introduce the ability to capture and restore only the changes (new, modified, or deleted files) since the last snapshot.
