### PR TITLE
Expand analysis service

### DIFF
--- a/FileSnap.Core/Models/DirectoryMetadata.cs
+++ b/FileSnap.Core/Models/DirectoryMetadata.cs
@@ -29,4 +29,9 @@ public class DirectoryMetadata
     /// Gets or sets the size of the directory.
     /// </summary>
     public long Size { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional metadata for the directory.
+    /// </summary>
+    public Dictionary<string, string>? AdditionalMetadata { get; set; }
 }

--- a/FileSnap.Core/Models/DirectoryMetadata.cs
+++ b/FileSnap.Core/Models/DirectoryMetadata.cs
@@ -1,0 +1,32 @@
+namespace FileSnap.Core.Models;
+
+/// <summary>
+/// Represents metadata for a directory.
+/// </summary>
+public class DirectoryMetadata
+{
+    /// <summary>
+    /// Gets or sets the directory path.
+    /// </summary>
+    public string? Path { get; set; }
+
+    /// <summary>
+    /// Gets or sets the creation time of the directory.
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the directory attributes.
+    /// </summary>
+    public FileAttributes Attributes { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last modified time of the directory.
+    /// </summary>
+    public DateTime LastModified { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size of the directory.
+    /// </summary>
+    public long Size { get; set; }
+}

--- a/FileSnap.Core/Models/DirectorySnapshot.cs
+++ b/FileSnap.Core/Models/DirectorySnapshot.cs
@@ -11,11 +11,6 @@ public class DirectorySnapshot
     public bool IsDeleted { get; set; }
 
     /// <summary>
-    /// Gets or sets the directory path.
-    /// </summary>
-    public string? Path { get; set; }
-
-    /// <summary>
     /// Gets or sets the list of file snapshots in the directory.
     /// </summary>
     public List<FileSnapshot> Files { get; set; } = [];

--- a/FileSnap.Core/Models/DirectorySnapshot.cs
+++ b/FileSnap.Core/Models/DirectorySnapshot.cs
@@ -26,13 +26,7 @@ public class DirectorySnapshot
     public List<DirectorySnapshot> Directories { get; set; } = [];
 
     /// <summary>
-    /// Gets or sets the creation time of the directory.
+    /// Gets or sets the directory metadata.
     /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// Gets or sets the directory attributes.
-    /// </summary>
-    public FileAttributes Attributes { get; set; }
+    public DirectoryMetadata Metadata { get; set; } = new DirectoryMetadata();
 }
-

--- a/FileSnap.Core/Models/FileMetadata.cs
+++ b/FileSnap.Core/Models/FileMetadata.cs
@@ -34,4 +34,9 @@ public class FileMetadata
     /// Gets or sets the file attributes.
     /// </summary>
     public FileAttributes Attributes { get; set; }
+
+    /// <summary>
+    /// Gets or sets additional metadata for the file.
+    /// </summary>
+    public Dictionary<string, string>? AdditionalMetadata { get; set; }
 }

--- a/FileSnap.Core/Models/FileMetadata.cs
+++ b/FileSnap.Core/Models/FileMetadata.cs
@@ -1,0 +1,37 @@
+namespace FileSnap.Core.Models;
+
+/// <summary>
+/// Represents metadata for a file.
+/// </summary>
+public class FileMetadata
+{
+    /// <summary>
+    /// Gets or sets the file path.
+    /// </summary>
+    public string? Path { get; set; }
+
+    /// <summary>
+    /// Gets or sets the size of the file.
+    /// </summary>
+    public long Size { get; set; }
+
+    /// <summary>
+    /// Gets or sets the hash of the file content.
+    /// </summary>
+    public string? Hash { get; set; }
+
+    /// <summary>
+    /// Gets or sets the last modified time of the file.
+    /// </summary>
+    public DateTime LastModified { get; set; }
+
+    /// <summary>
+    /// Gets or sets the creation time of the file.
+    /// </summary>
+    public DateTime CreatedAt { get; set; }
+
+    /// <summary>
+    /// Gets or sets the file attributes.
+    /// </summary>
+    public FileAttributes Attributes { get; set; }
+}

--- a/FileSnap.Core/Models/FileSnapshot.cs
+++ b/FileSnap.Core/Models/FileSnapshot.cs
@@ -11,34 +11,9 @@ public class FileSnapshot
     public bool IsDeleted { get; set; }
 
     /// <summary>
-    /// Gets or sets the file path.
+    /// Gets or sets the file metadata.
     /// </summary>
-    public string? Path { get; set; }
-
-    /// <summary>
-    /// Gets or sets the hash of the file content.
-    /// </summary>
-    public string? Hash { get; set; }
-
-    /// <summary>
-    /// Gets or sets the size of the file.
-    /// </summary>
-    public long Size { get; set; }
-
-    /// <summary>
-    /// Gets or sets the last modified time of the file.
-    /// </summary>
-    public DateTime LastModified { get; set; }
-
-    /// <summary>
-    /// Gets or sets the creation time of the file.
-    /// </summary>
-    public DateTime CreatedAt { get; set; }
-
-    /// <summary>
-    /// Gets or sets the file attributes.
-    /// </summary>
-    public FileAttributes Attributes { get; set; }
+    public FileMetadata Metadata { get; set; } = new FileMetadata();
 
     /// <summary>
     /// Gets or sets the content of the file.
@@ -50,4 +25,3 @@ public class FileSnapshot
     /// </summary>
     public byte[]? CompressedContent { get; set; }
 }
-

--- a/FileSnap.Core/Models/SystemSnapshot.cs
+++ b/FileSnap.Core/Models/SystemSnapshot.cs
@@ -30,6 +30,7 @@ public class SystemSnapshot
     /// </summary>
     public Dictionary<string, string>? Insights { get; set; }
   
+    /// <summary>
     /// Gets or sets the additional metadata for the snapshot.
     /// </summary>
     public Dictionary<string, string>? Metadata { get; set; }

--- a/FileSnap.Core/Services/AnalysisService.cs
+++ b/FileSnap.Core/Services/AnalysisService.cs
@@ -42,31 +42,6 @@ public class AnalysisService : IAnalysisService
     }
 
     /// <inheritdoc />
-    public (int fileCount, int directoryCount) GetFileAndDirectoryCount(SystemSnapshot snapshot)
-    {
-        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
-
-        int fileCount = 0;
-        int directoryCount = 0;
-
-        TraverseDirectory(snapshot.RootDirectory, ref fileCount, ref directoryCount);
-
-        return (fileCount, directoryCount);
-    }
-
-    /// <inheritdoc />
-    public long GetTotalFileSize(SystemSnapshot snapshot)
-    {
-        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
-
-        long totalSize = 0;
-
-        TraverseDirectory(snapshot.RootDirectory, ref totalSize);
-
-        return totalSize;
-    }
-
-    /// <inheritdoc />
     public double GetAverageFileSize(SystemSnapshot snapshot)
     {
         ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
@@ -77,59 +52,6 @@ public class AnalysisService : IAnalysisService
         TraverseDirectory(snapshot.RootDirectory, ref totalSize, ref fileCount);
 
         return fileCount == 0 ? 0 : (double)totalSize / fileCount;
-    }
-
-    /// <inheritdoc />
-    public (FileSnapshot largestFile, FileSnapshot smallestFile) GetLargestAndSmallestFiles(SystemSnapshot snapshot)
-    {
-        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
-
-        FileSnapshot? largestFile = null;
-        FileSnapshot? smallestFile = null;
-
-        TraverseDirectory(snapshot.RootDirectory, ref largestFile, ref smallestFile);
-
-        return (largestFile!, smallestFile!);
-    }
-
-    /// <inheritdoc />
-    public Dictionary<string, int> GetFileTypeCount(SystemSnapshot snapshot)
-    {
-        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
-
-        var fileTypeCount = new Dictionary<string, int>();
-
-        TraverseDirectory(snapshot.RootDirectory, fileTypeCount);
-
-        return fileTypeCount;
-    }
-
-    /// <inheritdoc />
-    public Dictionary<string, long> GetFileTypeSize(SystemSnapshot snapshot)
-    {
-        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
-
-        var fileTypeSize = new Dictionary<string, long>();
-
-        TraverseDirectory(snapshot.RootDirectory, fileTypeSize);
-
-        return fileTypeSize;
-    }
-
-    /// <inheritdoc />
-    public string GetMostCommonFileType(SystemSnapshot snapshot)
-    {
-        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
-
-        var fileTypeCount = GetFileTypeCount(snapshot);
-
-        return fileTypeCount.OrderByDescending(kvp => kvp.Value).FirstOrDefault().Key;
-    }
-
-    /// <inheritdoc />
-    public (int addedFiles, int deletedFiles, int modifiedFiles) GetFileChanges(SnapshotDifference difference)
-    {
-        return (difference.NewFiles.Count, difference.DeletedFiles.Count, difference.ModifiedFiles.Count);
     }
 
     /// <inheritdoc />
@@ -151,16 +73,6 @@ public class AnalysisService : IAnalysisService
     }
 
     /// <summary>
-    /// Retrieves metadata for a given file.
-    /// </summary>
-    public FileMetadata GetFileMetadata(FileSnapshot file)
-    {
-        ArgumentNullException.ThrowIfNull(file);
-
-        return file.Metadata;
-    }
-
-    /// <summary>
     /// Retrieves metadata for a given directory.
     /// </summary>
     public DirectoryMetadata GetDirectoryMetadata(DirectorySnapshot directory)
@@ -168,20 +80,6 @@ public class AnalysisService : IAnalysisService
         ArgumentNullException.ThrowIfNull(directory);
 
         return directory.Metadata;
-    }
-
-    /// <summary>
-    /// Analyzes file size distribution in the snapshot.
-    /// </summary>
-    public Dictionary<long, int> GetFileSizeDistribution(SystemSnapshot snapshot)
-    {
-        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
-
-        var sizeDistribution = new Dictionary<long, int>();
-
-        TraverseDirectory(snapshot.RootDirectory, sizeDistribution);
-
-        return sizeDistribution;
     }
 
     /// <summary>
@@ -212,7 +110,109 @@ public class AnalysisService : IAnalysisService
         return attributeDistribution;
     }
 
-    private static void TraverseDirectory(DirectorySnapshot directory, ref int fileCount, ref int directoryCount)
+    /// <inheritdoc />
+    public (int addedFiles, int deletedFiles, int modifiedFiles) GetFileChanges(SnapshotDifference difference)
+    {
+        return (difference.NewFiles.Count, difference.DeletedFiles.Count, difference.ModifiedFiles.Count);
+    }
+
+    /// <summary>
+    /// Retrieves metadata for a given file.
+    /// </summary>
+    public FileMetadata GetFileMetadata(FileSnapshot file)
+    {
+        ArgumentNullException.ThrowIfNull(file);
+
+        return file.Metadata;
+    }
+
+    /// <inheritdoc />
+    public (int fileCount, int directoryCount) GetFileAndDirectoryCount(SystemSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
+
+        int fileCount = 0;
+        int directoryCount = 0;
+
+        TraverseDirectory(snapshot.RootDirectory, ref fileCount, ref directoryCount);
+
+        return (fileCount, directoryCount);
+    }
+
+    /// <summary>
+    /// Analyzes file size distribution in the snapshot.
+    /// </summary>
+    public Dictionary<long, int> GetFileSizeDistribution(SystemSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
+
+        var sizeDistribution = new Dictionary<long, int>();
+
+        TraverseDirectory(snapshot.RootDirectory, sizeDistribution);
+
+        return sizeDistribution;
+    }
+
+    /// <inheritdoc />
+    public Dictionary<string, int> GetFileTypeCount(SystemSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
+
+        var fileTypeCount = new Dictionary<string, int>();
+
+        TraverseDirectory(snapshot.RootDirectory, fileTypeCount);
+
+        return fileTypeCount;
+    }
+
+    /// <inheritdoc />
+    public Dictionary<string, long> GetFileTypeSize(SystemSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
+
+        var fileTypeSize = new Dictionary<string, long>();
+
+        TraverseDirectory(snapshot.RootDirectory, fileTypeSize);
+
+        return fileTypeSize;
+    }
+
+    /// <inheritdoc />
+    public (FileSnapshot largestFile, FileSnapshot smallestFile) GetLargestAndSmallestFiles(SystemSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
+
+        FileSnapshot? largestFile = null;
+        FileSnapshot? smallestFile = null;
+
+        TraverseDirectory(snapshot.RootDirectory, ref largestFile, ref smallestFile);
+
+        return (largestFile!, smallestFile!);
+    }
+
+    /// <inheritdoc />
+    public string GetMostCommonFileType(SystemSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
+
+        var fileTypeCount = GetFileTypeCount(snapshot);
+
+        return fileTypeCount.OrderByDescending(kvp => kvp.Value).FirstOrDefault().Key;
+    }
+
+    /// <inheritdoc />
+    public long GetTotalFileSize(SystemSnapshot snapshot)
+    {
+        ArgumentNullException.ThrowIfNull(snapshot.RootDirectory);
+
+        long totalSize = 0;
+
+        TraverseDirectory(snapshot.RootDirectory, ref totalSize);
+
+        return totalSize;
+    }
+
+    private void TraverseDirectory(DirectorySnapshot directory, ref int fileCount, ref int directoryCount)
     {
         directoryCount++;
 
@@ -227,7 +227,7 @@ public class AnalysisService : IAnalysisService
         }
     }
 
-    private static void TraverseDirectory(DirectorySnapshot directory, ref long totalSize)
+    private void TraverseDirectory(DirectorySnapshot directory, ref long totalSize)
     {
         foreach (var file in directory.Files)
         {
@@ -240,7 +240,7 @@ public class AnalysisService : IAnalysisService
         }
     }
 
-    private static void TraverseDirectory(DirectorySnapshot directory, ref long totalSize, ref int fileCount)
+    private void TraverseDirectory(DirectorySnapshot directory, ref long totalSize, ref int fileCount)
     {
         foreach (var file in directory.Files)
         {
@@ -254,7 +254,7 @@ public class AnalysisService : IAnalysisService
         }
     }
 
-    private static void TraverseDirectory(DirectorySnapshot directory, ref FileSnapshot? largestFile, ref FileSnapshot? smallestFile)
+    private void TraverseDirectory(DirectorySnapshot directory, ref FileSnapshot? largestFile, ref FileSnapshot? smallestFile)
     {
         foreach (var file in directory.Files)
         {
@@ -275,7 +275,7 @@ public class AnalysisService : IAnalysisService
         }
     }
 
-    private static void TraverseDirectory(DirectorySnapshot directory, Dictionary<string, int> fileTypeCount)
+    private void TraverseDirectory(DirectorySnapshot directory, Dictionary<string, int> fileTypeCount)
     {
         foreach (var file in directory.Files)
         {
@@ -296,7 +296,7 @@ public class AnalysisService : IAnalysisService
         }
     }
 
-    private static void TraverseDirectory(DirectorySnapshot directory, Dictionary<string, long> fileTypeSize)
+    private void TraverseDirectory(DirectorySnapshot directory, Dictionary<string, long> fileTypeSize)
     {
         foreach (var file in directory.Files)
         {
@@ -316,16 +316,17 @@ public class AnalysisService : IAnalysisService
         }
     }
 
-    private static void TraverseDirectory(DirectorySnapshot directory, Dictionary<long, int> sizeDistribution)
+    private void TraverseDirectory(DirectorySnapshot directory, Dictionary<long, int> sizeDistribution)
     {
         foreach (var file in directory.Files)
         {
-            if (!sizeDistribution.ContainsKey(file.Metadata.Size))
+            if (!sizeDistribution.TryGetValue(file.Metadata.Size, out int value))
             {
-                sizeDistribution[file.Metadata.Size] = 0;
+                value = 0;
+                sizeDistribution[file.Metadata.Size] = value;
             }
 
-            sizeDistribution[file.Metadata.Size]++;
+            sizeDistribution[file.Metadata.Size] = ++value;
         }
 
         foreach (var subDirectory in directory.Directories)
@@ -334,17 +335,18 @@ public class AnalysisService : IAnalysisService
         }
     }
 
-    private static void TraverseDirectory(DirectorySnapshot directory, Dictionary<long, int> sizeDistribution, bool isDirectory)
+    private void TraverseDirectory(DirectorySnapshot directory, Dictionary<long, int> sizeDistribution, bool isDirectory)
     {
-        if (isDirectory)
+       if (isDirectory)
         {
             long directorySize = directory.Files.Sum(file => file.Metadata.Size);
-            if (!sizeDistribution.ContainsKey(directorySize))
+            if (!sizeDistribution.TryGetValue(directorySize, out int value))
             {
-                sizeDistribution[directorySize] = 0;
+                value = 0;
+                sizeDistribution[directorySize] = value;
             }
 
-            sizeDistribution[directorySize]++;
+            sizeDistribution[directorySize] = ++value;
         }
 
         foreach (var subDirectory in directory.Directories)
@@ -353,16 +355,17 @@ public class AnalysisService : IAnalysisService
         }
     }
 
-    private static void TraverseDirectory(DirectorySnapshot directory, Dictionary<FileAttributes, int> attributeDistribution)
+    private void TraverseDirectory(DirectorySnapshot directory, Dictionary<FileAttributes, int> attributeDistribution)
     {
         foreach (var file in directory.Files)
         {
-            if (!attributeDistribution.ContainsKey(file.Metadata.Attributes))
+            if (!attributeDistribution.TryGetValue(file.Metadata.Attributes, out int value))
             {
-                attributeDistribution[file.Metadata.Attributes] = 0;
+                value = 0;
+                attributeDistribution[file.Metadata.Attributes] = value;
             }
 
-            attributeDistribution[file.Metadata.Attributes]++;
+            attributeDistribution[file.Metadata.Attributes] = ++value;
         }
 
         foreach (var subDirectory in directory.Directories)

--- a/FileSnap.Core/Services/ComparisonService.cs
+++ b/FileSnap.Core/Services/ComparisonService.cs
@@ -36,19 +36,19 @@ public class ComparisonService : IComparisonService
     {
         // Compare files.
         var beforeFiles = before.Files
-            .Where(f => f.Path != null)
-            .ToDictionary(f => f.Path!);
+            .Where(f => f.Metadata.Path != null)
+            .ToDictionary(f => f.Metadata.Path!);
         var afterFiles = after.Files
-            .Where(f => f.Path != null)
-            .ToDictionary(f => f.Path!);
+            .Where(f => f.Metadata.Path != null)
+            .ToDictionary(f => f.Metadata.Path!);
 
         foreach (var afterFile in afterFiles.Values)
         {
-            if (!beforeFiles.TryGetValue(afterFile.Path!, out var beforeFile))
+            if (!beforeFiles.TryGetValue(afterFile.Metadata.Path!, out var beforeFile))
             {
                 difference.NewFiles.Add(afterFile);
             }
-            else if (beforeFile.Hash != afterFile.Hash)
+            else if (beforeFile.Metadata.Hash != afterFile.Metadata.Hash)
             {
                 difference.ModifiedFiles.Add((beforeFile, afterFile));
             }
@@ -56,7 +56,7 @@ public class ComparisonService : IComparisonService
 
         foreach (var beforeFile in beforeFiles.Values)
         {
-            if (!afterFiles.ContainsKey(beforeFile.Path!))
+            if (!afterFiles.ContainsKey(beforeFile.Metadata.Path!))
             {
                 beforeFile.IsDeleted = true;
                 difference.DeletedFiles.Add(beforeFile);
@@ -65,20 +65,20 @@ public class ComparisonService : IComparisonService
 
         // Compare directories.
         var beforeDirs = before.Directories
-            .Where(d => d.Path != null)
-            .ToDictionary(d => d.Path!);
+            .Where(d => d.Metadata.Path != null)
+            .ToDictionary(d => d.Metadata.Path!);
         var afterDirs = after.Directories
-            .Where(d => d.Path != null)
-            .ToDictionary(d => d.Path!);
+            .Where(d => d.Metadata.Path != null)
+            .ToDictionary(d => d.Metadata.Path!);
 
         foreach (var afterDir in afterDirs.Values)
         {
-            if (afterDir.Path == null)
+            if (afterDir.Metadata.Path == null)
             {
                 continue;
             }
 
-            if (!beforeDirs.TryGetValue(afterDir.Path, out var beforeDir))
+            if (!beforeDirs.TryGetValue(afterDir.Metadata.Path, out var beforeDir))
             {
                 difference.NewDirectories.Add(afterDir);
             }
@@ -86,7 +86,8 @@ public class ComparisonService : IComparisonService
             {
                 CompareDirectories(beforeDir, afterDir, difference);
 
-                if (beforeDir.CreatedAt != afterDir.CreatedAt || beforeDir.Attributes != afterDir.Attributes)
+                if (beforeDir.Metadata.CreatedAt != afterDir.Metadata.CreatedAt 
+                    || beforeDir.Metadata.Attributes != afterDir.Metadata.Attributes)
                 {
                     difference.ModifiedDirectories.Add((beforeDir, afterDir));
                 }
@@ -95,12 +96,12 @@ public class ComparisonService : IComparisonService
 
         foreach (var beforeDir in beforeDirs.Values)
         {
-            if (beforeDir.Path == null)
+            if (beforeDir.Metadata.Path == null)
             {
                 continue;
             }
 
-            if (!afterDirs.ContainsKey(beforeDir.Path))
+            if (!afterDirs.ContainsKey(beforeDir.Metadata.Path))
             {
                 beforeDir.IsDeleted = true;
                 difference.DeletedDirectories.Add(beforeDir);

--- a/FileSnap.Core/Services/RestorationService.cs
+++ b/FileSnap.Core/Services/RestorationService.cs
@@ -41,10 +41,10 @@ public class RestorationService : IRestorationService
     /// </summary>
     private async Task RestoreDirectoryAsync(DirectorySnapshot directorySnapshot, string targetPath)
     {
-        if (directorySnapshot.Path == null)
+        if (directorySnapshot.Metadata.Path == null)
             throw new SnapshotException("Directory snapshot path is null.");
 
-        var targetDir = Path.Combine(targetPath, directorySnapshot.Path);
+        var targetDir = Path.Combine(targetPath, directorySnapshot.Metadata.Path);
 
         if (directorySnapshot.IsDeleted)
         {
@@ -77,10 +77,10 @@ public class RestorationService : IRestorationService
         if (fileSnapshot.Content == null)
             throw new SnapshotException("File snapshot content is null.");
 
-        if (fileSnapshot.Path == null)
+        if (fileSnapshot.Metadata.Path == null)
             throw new SnapshotException("File snapshot path is null.");
 
-        var targetFile = Path.Combine(targetPath, Path.GetFileName(fileSnapshot.Path));
+        var targetFile = Path.Combine(targetPath, Path.GetFileName(fileSnapshot.Metadata.Path));
 
         if (fileSnapshot.IsDeleted)
         {
@@ -102,19 +102,19 @@ public class RestorationService : IRestorationService
         // Set file attributes and timestamps.
         try
         {
-            File.SetAttributes(targetFile, fileSnapshot.Attributes);
+            File.SetAttributes(targetFile, fileSnapshot.Metadata.Attributes);
         }
         catch { }
 
         try
         {
-            File.SetCreationTimeUtc(targetFile, fileSnapshot.CreatedAt);
+            File.SetCreationTimeUtc(targetFile, fileSnapshot.Metadata.CreatedAt);
         }
         catch { }
 
         try
         {
-            File.SetLastWriteTimeUtc(targetFile, fileSnapshot.LastModified);
+            File.SetLastWriteTimeUtc(targetFile, fileSnapshot.Metadata.LastModified);
         }
         catch { }
     }

--- a/FileSnap.Core/Services/SnapshotService.cs
+++ b/FileSnap.Core/Services/SnapshotService.cs
@@ -1,4 +1,4 @@
-﻿using FileSnap.Core.Exceptions;
+using FileSnap.Core.Exceptions;
 using FileSnap.Core.Models;
 using FileSnap.Core.Utilities;
 using System.Text.Json;
@@ -121,7 +121,7 @@ public class SnapshotService : ISnapshotService
     /// <param name="metadata">Additional metadata to include in the snapshot.</param>
     /// <returns>A <see cref="SystemSnapshot"/> containing the captured directory structure and metadata.</returns>
     /// <exception cref="SnapshotException">Thrown when the specified directory does not exist.</exception>
-    public async Task<SystemSnapshot> CaptureSnapshotWithMetadataAsync(string path, FileMetadata metadata)
+    public async Task<SystemSnapshot> CaptureSnapshotWithMetadataAsync(string path, Dictionary<string, string> metadata)
     {
         if (!Directory.Exists(path))
             throw new SnapshotException($"Directory not found: {path}");
@@ -132,15 +132,7 @@ public class SnapshotService : ISnapshotService
             CreatedAt = DateTime.UtcNow,
             BasePath = path,
             RootDirectory = await CaptureDirectoryAsync(path),
-            Metadata = new Dictionary<string, string>
-            {
-                { "Path", metadata.Path },
-                { "Size", metadata.Size.ToString() },
-                { "Hash", metadata.Hash },
-                { "LastModified", metadata.LastModified.ToString() },
-                { "CreatedAt", metadata.CreatedAt.ToString() },
-                { "Attributes", metadata.Attributes.ToString() }
-            }
+            AdditionalMetadata = metadata,
         };
 
         return snapshot;
@@ -154,7 +146,7 @@ public class SnapshotService : ISnapshotService
     /// <param name="metadata">Additional metadata to include in the snapshot.</param>
     /// <returns>A <see cref="SystemSnapshot"/> containing the captured incremental directory structure and metadata.</returns>
     /// <exception cref="SnapshotException">Thrown when the specified directory does not exist.</exception>
-    public async Task<SystemSnapshot> CaptureIncrementalSnapshotWithMetadataAsync(string path, SystemSnapshot previousSnapshot, FileMetadata metadata)
+    public async Task<SystemSnapshot> CaptureIncrementalSnapshotWithMetadataAsync(string path, SystemSnapshot previousSnapshot, Dictionary<string, string> metadata)
     {
         if (!Directory.Exists(path))
             throw new SnapshotException($"Directory not found: {path}");
@@ -173,15 +165,7 @@ public class SnapshotService : ISnapshotService
                 Files = [.. difference.NewFiles, .. difference.ModifiedFiles.Select(m => m.After), .. difference.DeletedFiles],
                 Directories = [.. difference.NewDirectories, .. difference.ModifiedDirectories.Select(m => m.After), .. difference.DeletedDirectories]
             },
-            Metadata = new Dictionary<string, string>
-            {
-                { "Path", metadata.Path },
-                { "Size", metadata.Size.ToString() },
-                { "Hash", metadata.Hash },
-                { "LastModified", metadata.LastModified.ToString() },
-                { "CreatedAt", metadata.CreatedAt.ToString() },
-                { "Attributes", metadata.Attributes.ToString() }
-            }
+            AdditionalMetadata = metadata,
         };
 
         return incrementalSnapshot;

--- a/FileSnap.Tests/AnalysisServiceTests.cs
+++ b/FileSnap.Tests/AnalysisServiceTests.cs
@@ -165,6 +165,21 @@ public class AnalysisServiceTests
     }
 
     [Fact]
+    public async Task AnalyzeSnapshotAsync_ShouldReturnCorrectInsights()
+    {
+        // Arrange
+        var snapshot = CreateTestSnapshot();
+
+        // Act
+        var insights = await _analysisService.AnalyzeSnapshotAsync(snapshot);
+
+        // Assert
+        Assert.NotNull(insights);
+        Assert.Equal("4", insights["FileCount"]);
+        Assert.Equal("1", insights["DirectoryCount"]);
+    }
+
+    [Fact]
     public void GetFileMetadata_ShouldReturnCorrectMetadata()
     {
         // Arrange
@@ -242,7 +257,7 @@ public class AnalysisServiceTests
         var sizeDistribution = _analysisService.GetDirectorySizeDistribution(snapshot);
 
         // Assert
-        Assert.Equal(1, sizeDistribution[700]);
+        Assert.Equal(1, sizeDistribution[800]);
         Assert.Equal(1, sizeDistribution[400]);
     }
 

--- a/FileSnap.Tests/AnalysisServiceTests.cs
+++ b/FileSnap.Tests/AnalysisServiceTests.cs
@@ -62,8 +62,8 @@ public class AnalysisServiceTests
         var (largestFile, smallestFile) = _analysisService.GetLargestAndSmallestFiles(snapshot);
 
         // Assert
-        Assert.Equal("file3.jpg", largestFile.Path);
-        Assert.Equal("file1.txt", smallestFile.Path);
+        Assert.Equal("file3.jpg", largestFile.Metadata.Path);
+        Assert.Equal("file1.txt", smallestFile.Metadata.Path);
     }
 
     [Fact]
@@ -164,6 +164,101 @@ public class AnalysisServiceTests
         Assert.True(true); // If no exception is thrown, the test passes
     }
 
+    [Fact]
+    public void GetFileMetadata_ShouldReturnCorrectMetadata()
+    {
+        // Arrange
+        var file = new FileSnapshot
+        {
+            Metadata = new FileMetadata
+            {
+                Path = "file1.txt",
+                Size = 100,
+                Hash = "hash1",
+                LastModified = DateTime.UtcNow,
+                CreatedAt = DateTime.UtcNow,
+                Attributes = FileAttributes.Normal
+            }
+        };
+
+        // Act
+        var metadata = _analysisService.GetFileMetadata(file);
+
+        // Assert
+        Assert.Equal("file1.txt", metadata.Path);
+        Assert.Equal(100, metadata.Size);
+        Assert.Equal("hash1", metadata.Hash);
+        Assert.Equal(file.Metadata.LastModified, metadata.LastModified);
+        Assert.Equal(file.Metadata.CreatedAt, metadata.CreatedAt);
+        Assert.Equal(FileAttributes.Normal, metadata.Attributes);
+    }
+
+    [Fact]
+    public void GetDirectoryMetadata_ShouldReturnCorrectMetadata()
+    {
+        // Arrange
+        var directory = new DirectorySnapshot
+        {
+            Metadata = new DirectoryMetadata
+            {
+                Path = "dir1",
+                CreatedAt = DateTime.UtcNow,
+                Attributes = FileAttributes.Directory
+            }
+        };
+
+        // Act
+        var metadata = _analysisService.GetDirectoryMetadata(directory);
+
+        // Assert
+        Assert.Equal("dir1", metadata.Path);
+        Assert.Equal(directory.Metadata.CreatedAt, metadata.CreatedAt);
+        Assert.Equal(FileAttributes.Directory, metadata.Attributes);
+    }
+
+    [Fact]
+    public void GetFileSizeDistribution_ShouldReturnCorrectDistribution()
+    {
+        // Arrange
+        var snapshot = CreateTestSnapshot();
+
+        // Act
+        var sizeDistribution = _analysisService.GetFileSizeDistribution(snapshot);
+
+        // Assert
+        Assert.Equal(1, sizeDistribution[100]);
+        Assert.Equal(1, sizeDistribution[200]);
+        Assert.Equal(1, sizeDistribution[500]);
+        Assert.Equal(1, sizeDistribution[400]);
+    }
+
+    [Fact]
+    public void GetDirectorySizeDistribution_ShouldReturnCorrectDistribution()
+    {
+        // Arrange
+        var snapshot = CreateTestSnapshot();
+
+        // Act
+        var sizeDistribution = _analysisService.GetDirectorySizeDistribution(snapshot);
+
+        // Assert
+        Assert.Equal(1, sizeDistribution[700]);
+        Assert.Equal(1, sizeDistribution[400]);
+    }
+
+    [Fact]
+    public void GetFileAttributeDistribution_ShouldReturnCorrectDistribution()
+    {
+        // Arrange
+        var snapshot = CreateTestSnapshot();
+
+        // Act
+        var attributeDistribution = _analysisService.GetFileAttributeDistribution(snapshot);
+
+        // Assert
+        Assert.Equal(4, attributeDistribution[FileAttributes.Normal]);
+    }
+
     private static SystemSnapshot CreateTestSnapshot()
     {
         return new SystemSnapshot
@@ -172,9 +267,9 @@ public class AnalysisServiceTests
             {
                 Files =
                 [
-                    new FileSnapshot { Path = "file1.txt", Size = 100 },
-                    new FileSnapshot { Path = "file2.txt", Size = 200 },
-                    new FileSnapshot { Path = "file3.jpg", Size = 500 }
+                    new FileSnapshot { Metadata = new FileMetadata { Path = "file1.txt", Size = 100, Attributes = FileAttributes.Normal } },
+                    new FileSnapshot { Metadata = new FileMetadata { Path = "file2.txt", Size = 200, Attributes = FileAttributes.Normal } },
+                    new FileSnapshot { Metadata = new FileMetadata { Path = "file3.jpg", Size = 500, Attributes = FileAttributes.Normal } }
                 ],
                 Directories =
                 [
@@ -182,7 +277,7 @@ public class AnalysisServiceTests
                     {
                         Files =
                         [
-                            new FileSnapshot { Path = "subdir/file4.txt", Size = 400 }
+                            new FileSnapshot { Metadata = new FileMetadata { Path = "subdir/file4.txt", Size = 400, Attributes = FileAttributes.Normal } }
                         ]
                     }
                 ]
@@ -194,12 +289,12 @@ public class AnalysisServiceTests
     {
         return new SnapshotDifference
         {
-            NewFiles = [new FileSnapshot { Path = "newfile.txt" }],
-            DeletedFiles = [new FileSnapshot { Path = "deletedfile.txt" }],
-            ModifiedFiles = [(new FileSnapshot { Path = "modifiedfile.txt" }, new FileSnapshot { Path = "modifiedfile.txt" })],
-            NewDirectories = [new DirectorySnapshot { Path = "newdir" }],
-            DeletedDirectories = [new DirectorySnapshot { Path = "deleteddir" }],
-            ModifiedDirectories = [ (new DirectorySnapshot { Path = "modifieddir" }, new DirectorySnapshot { Path = "modifieddir" })]
+            NewFiles = [new FileSnapshot { Metadata = new FileMetadata { Path = "newfile.txt" } }],
+            DeletedFiles = [new FileSnapshot { Metadata = new FileMetadata { Path = "deletedfile.txt" } }],
+            ModifiedFiles = [(new FileSnapshot { Metadata = new FileMetadata { Path = "modifiedfile.txt" } }, new FileSnapshot { Metadata = new FileMetadata { Path = "modifiedfile.txt" } })],
+            NewDirectories = [new DirectorySnapshot { Metadata = new DirectoryMetadata { Path = "newdir" } }],
+            DeletedDirectories = [new DirectorySnapshot { Metadata = new DirectoryMetadata { Path = "deleteddir" } }],
+            ModifiedDirectories = [ (new DirectorySnapshot { Metadata = new DirectoryMetadata { Path = "modifieddir" } }, new DirectorySnapshot { Metadata = new DirectoryMetadata { Path = "modifieddir" } })]
         };
     }
 }

--- a/FileSnap.Tests/ComparisonServiceTests.cs
+++ b/FileSnap.Tests/ComparisonServiceTests.cs
@@ -31,7 +31,7 @@ public class ComparisonServiceTests : IDisposable
         // Arrange
         var before = CreateSnapshot();
         var after = CreateSnapshot();
-        after.RootDirectory!.Files.Add(new FileSnapshot { Path = "new.txt", Hash = "hash" });
+        after.RootDirectory!.Files.Add(new FileSnapshot { Metadata = new() { Path = "new.txt", Hash = "hash" } });
 
         // Act
         var difference = _comparisonService.Compare(before, after);
@@ -47,7 +47,7 @@ public class ComparisonServiceTests : IDisposable
     {
         // Arrange
         var before = CreateSnapshot();
-        before.RootDirectory!.Files.Add(new FileSnapshot { Path = "old.txt", Hash = "hash" });
+        before.RootDirectory!.Files.Add(new FileSnapshot { Metadata = new() { Path = "old.txt", Hash = "hash" } });
         var after = CreateSnapshot();
 
         // Act
@@ -64,9 +64,9 @@ public class ComparisonServiceTests : IDisposable
     {
         // Arrange
         var before = CreateSnapshot();
-        before.RootDirectory!.Files.Add(new FileSnapshot { Path = "file.txt", Hash = "oldhash" });
+        before.RootDirectory!.Files.Add(new FileSnapshot { Metadata = new() { Path = "file.txt", Hash = "oldhash" } });
         var after = CreateSnapshot();
-        after.RootDirectory!.Files.Add(new FileSnapshot { Path = "file.txt", Hash = "newhash" });
+        after.RootDirectory!.Files.Add(new FileSnapshot { Metadata = new() { Path = "file.txt", Hash = "newhash" } });
 
         // Act
         var difference = _comparisonService.Compare(before, after);
@@ -83,7 +83,7 @@ public class ComparisonServiceTests : IDisposable
         // Arrange
         var before = CreateSnapshot();
         var after = CreateSnapshot();
-        after.RootDirectory!.Directories.Add(new DirectorySnapshot { Path = "newdir" });
+        after.RootDirectory!.Directories.Add(new DirectorySnapshot { Metadata = new() { Path = "newdir" } });
 
         // Act
         var difference = _comparisonService.Compare(before, after);
@@ -99,7 +99,7 @@ public class ComparisonServiceTests : IDisposable
     {
         // Arrange
         var before = CreateSnapshot();
-        before.RootDirectory!.Directories.Add(new DirectorySnapshot { Path = "olddir" });
+        before.RootDirectory!.Directories.Add(new DirectorySnapshot { Metadata = new() { Path = "olddir" } });
         var after = CreateSnapshot();
 
         // Act
@@ -116,9 +116,9 @@ public class ComparisonServiceTests : IDisposable
     {
         // Arrange
         var before = CreateSnapshot();
-        before.RootDirectory!.Directories.Add(new DirectorySnapshot { Path = "dir", CreatedAt = DateTime.UtcNow.AddDays(-1) });
+        before.RootDirectory!.Directories.Add(new DirectorySnapshot { Metadata = new() { Path = "dir", CreatedAt = DateTime.UtcNow.AddDays(-1) } });
         var after = CreateSnapshot();
-        after.RootDirectory!.Directories.Add(new DirectorySnapshot { Path = "dir", CreatedAt = DateTime.UtcNow });
+        after.RootDirectory!.Directories.Add(new DirectorySnapshot {Metadata = new() { Path = "dir", CreatedAt = DateTime.UtcNow } });
 
         // Act
         var difference = _comparisonService.Compare(before, after);
@@ -134,14 +134,14 @@ public class ComparisonServiceTests : IDisposable
     {
         // Arrange
         var before = CreateSnapshot();
-        before.RootDirectory!.Files.Add(new FileSnapshot { Path = "file1.txt", Hash = "hash1" });
-        before.RootDirectory!.Files.Add(new FileSnapshot { Path = "file2.txt", Hash = "hash2" });
-        before.RootDirectory!.Directories.Add(new DirectorySnapshot { Path = "dir1" });
+        before.RootDirectory!.Files.Add(new FileSnapshot {Metadata = new() { Path = "file1.txt", Hash = "hash1" } });
+        before.RootDirectory!.Files.Add(new FileSnapshot {Metadata = new() { Path = "file2.txt", Hash = "hash2" } });
+        before.RootDirectory!.Directories.Add(new DirectorySnapshot { Metadata = new() { Path = "dir1" } });
 
         var after = CreateSnapshot();
-        after.RootDirectory!.Files.Add(new FileSnapshot { Path = "file2.txt", Hash = "newhash2" }); // Modified
-        after.RootDirectory!.Files.Add(new FileSnapshot { Path = "file3.txt", Hash = "hash3" }); // New
-        after.RootDirectory!.Directories.Add(new DirectorySnapshot { Path = "dir2" }); // New
+        after.RootDirectory!.Files.Add(new FileSnapshot {Metadata = new() { Path = "file2.txt", Hash = "newhash2" } }); // Modified
+        after.RootDirectory!.Files.Add(new FileSnapshot {Metadata = new() { Path = "file3.txt", Hash = "hash3" } }); // New
+        after.RootDirectory!.Directories.Add(new DirectorySnapshot { Metadata = new() { Path = "dir2" } }); // New
 
         // Act
         var difference = _comparisonService.Compare(before, after);
@@ -160,9 +160,9 @@ public class ComparisonServiceTests : IDisposable
             BasePath = "basepath",
             RootDirectory = new DirectorySnapshot
             {
-                Path = "basepath",
                 Files = [],
-                Directories = []
+                Directories = [],
+                Metadata = new() { Path = "basepath" },
             }
         };
 }

--- a/FileSnap.Tests/RestorationServiceTests.cs
+++ b/FileSnap.Tests/RestorationServiceTests.cs
@@ -128,7 +128,7 @@ public class RestorationServiceTests : IDisposable
         Directory.CreateDirectory(dirPath);
         File.WriteAllText(Path.Combine(dirPath, "file5.txt"), "This is a test file.");
         var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
-        snapshot.RootDirectory!.Files[0].CreatedAt = DateTime.MinValue; // Invalid creation time
+        snapshot.RootDirectory!.Files[0].Metadata.CreatedAt = DateTime.MinValue; // Invalid creation time
         var snapshotPath = Path.Combine(_testDir, "snapshot.json");
         await _snapshotService.SaveSnapshotAsync(snapshot, snapshotPath);
 

--- a/FileSnap.Tests/SnapshotServiceTests.cs
+++ b/FileSnap.Tests/SnapshotServiceTests.cs
@@ -64,8 +64,8 @@ public class SnapshotServiceTests : IDisposable
         Assert.NotNull(snapshot);
         Assert.Equal(dirPath, snapshot.BasePath);
         Assert.Equal(2, snapshot.RootDirectory!.Directories.Count);
-        Assert.Equal("SubDirA", Path.GetFileName(snapshot.RootDirectory.Directories[0].Path));
-        Assert.Equal("SubDirB", Path.GetFileName(snapshot.RootDirectory.Directories[1].Path));
+        Assert.Equal("SubDirA", Path.GetFileName(snapshot.RootDirectory.Directories[0].Metadata.Path));
+        Assert.Equal("SubDirB", Path.GetFileName(snapshot.RootDirectory.Directories[1].Metadata.Path));
     }
 
     [Fact]
@@ -84,8 +84,8 @@ public class SnapshotServiceTests : IDisposable
         Assert.NotNull(snapshot);
         Assert.Equal(dirPath, snapshot.BasePath);
         Assert.Equal(2, snapshot.RootDirectory!.Files.Count);
-        Assert.Equal("file1.txt", Path.GetFileName(snapshot.RootDirectory.Files[0].Path));
-        Assert.Equal("file2.txt", Path.GetFileName(snapshot.RootDirectory.Files[1].Path));
+        Assert.Equal("file1.txt", Path.GetFileName(snapshot.RootDirectory.Files[0].Metadata.Path));
+        Assert.Equal("file2.txt", Path.GetFileName(snapshot.RootDirectory.Files[1].Metadata.Path));
     }
 
     [Fact]
@@ -105,9 +105,9 @@ public class SnapshotServiceTests : IDisposable
         Assert.NotNull(snapshot);
         Assert.Equal(dirPath, snapshot.BasePath);
         Assert.Single(snapshot.RootDirectory!.Directories);
-        Assert.Equal("SubDir", Path.GetFileName(snapshot.RootDirectory.Directories[0].Path));
+        Assert.Equal("SubDir", Path.GetFileName(snapshot.RootDirectory.Directories[0].Metadata.Path));
         Assert.Single(snapshot.RootDirectory.Directories[0].Files);
-        Assert.Equal("file1.txt", Path.GetFileName(snapshot.RootDirectory.Directories[0].Files[0].Path));
+        Assert.Equal("file1.txt", Path.GetFileName(snapshot.RootDirectory.Directories[0].Files[0].Metadata.Path));
     }
 
     [Fact]
@@ -206,7 +206,7 @@ public class SnapshotServiceTests : IDisposable
         Assert.Equal(snapshot.Id, loadedSnapshot.Id);
         Assert.Equal(snapshot.BasePath, loadedSnapshot.BasePath);
         Assert.Single(loadedSnapshot.RootDirectory!.Files);
-        Assert.Equal("file1.txt", Path.GetFileName(loadedSnapshot.RootDirectory.Files[0].Path));
+        Assert.Equal("file1.txt", Path.GetFileName(loadedSnapshot.RootDirectory.Files[0].Metadata.Path));
         Assert.Equal("This is a test file.", Encoding.UTF8.GetString(loadedSnapshot.RootDirectory.Files[0].Content!));
     }
 
@@ -229,7 +229,7 @@ public class SnapshotServiceTests : IDisposable
         Assert.Equal(snapshot.Id, loadedSnapshot.Id);
         Assert.Equal(snapshot.BasePath, loadedSnapshot.BasePath);
         Assert.Single(loadedSnapshot.RootDirectory!.Files);
-        Assert.Equal("file1.txt", Path.GetFileName(loadedSnapshot.RootDirectory.Files[0].Path));
+        Assert.Equal("file1.txt", Path.GetFileName(loadedSnapshot.RootDirectory.Files[0].Metadata.Path));
         Assert.Equal("This is a test file.", Encoding.UTF8.GetString(loadedSnapshot.RootDirectory.Files[0].Content!));
     }
 
@@ -254,7 +254,7 @@ public class SnapshotServiceTests : IDisposable
         Assert.Equal(snapshot.Id, loadedSnapshot.Id);
         Assert.Equal(snapshot.BasePath, loadedSnapshot.BasePath);
         Assert.Single(loadedSnapshot.RootDirectory!.Files);
-        Assert.Equal("file1.txt", Path.GetFileName(loadedSnapshot.RootDirectory.Files[0].Path));
+        Assert.Equal("file1.txt", Path.GetFileName(loadedSnapshot.RootDirectory.Files[0].Metadata.Path));
         Assert.Equal("This is a test file.", Encoding.UTF8.GetString(loadedSnapshot.RootDirectory.Files[0].Content!));
     }
 
@@ -306,7 +306,7 @@ public class SnapshotServiceTests : IDisposable
 
         // Assert
         Assert.Single(incrementalSnapshot.RootDirectory!.Files);
-        Assert.Equal("newfile.txt", Path.GetFileName(incrementalSnapshot.RootDirectory.Files[0].Path));
+        Assert.Equal("newfile.txt", Path.GetFileName(incrementalSnapshot.RootDirectory.Files[0].Metadata.Path));
     }
 
     [Fact]
@@ -327,7 +327,7 @@ public class SnapshotServiceTests : IDisposable
 
         // Assert
         Assert.Single(incrementalSnapshot.RootDirectory!.Files);
-        Assert.Equal("file.txt", Path.GetFileName(incrementalSnapshot.RootDirectory.Files[0].Path));
+        Assert.Equal("file.txt", Path.GetFileName(incrementalSnapshot.RootDirectory.Files[0].Metadata.Path));
         Assert.True(incrementalSnapshot.RootDirectory.Files[0].IsDeleted);
     }
 
@@ -349,27 +349,8 @@ public class SnapshotServiceTests : IDisposable
 
         // Assert
         Assert.Single(incrementalSnapshot.RootDirectory!.Files);
-        Assert.Equal("file.txt", Path.GetFileName(incrementalSnapshot.RootDirectory.Files[0].Path));
-        Assert.NotEqual(initialSnapshot.RootDirectory!.Files[0].Hash, incrementalSnapshot.RootDirectory.Files[0].Hash);
-    }
-
-    [Fact]
-    public async Task AnalyzeSnapshotAsync_ShouldReturnCorrectInsights()
-    {
-        // Arrange
-        var dirPath = Path.Combine(_testDir, "AnalyzeDir");
-        Directory.CreateDirectory(dirPath);
-        File.WriteAllText(Path.Combine(dirPath, "file1.txt"), "This is a test file.");
-        Directory.CreateDirectory(Path.Combine(dirPath, "SubDir"));
-        var snapshot = await _snapshotService.CaptureSnapshotAsync(dirPath);
-
-        // Act
-        var insights = await _snapshotService.AnalyzeSnapshotAsync(snapshot);
-
-        // Assert
-        Assert.NotNull(insights);
-        Assert.Equal("1", insights["FileCount"]);
-        Assert.Equal("1", insights["DirectoryCount"]);
+        Assert.Equal("file.txt", Path.GetFileName(incrementalSnapshot.RootDirectory.Files[0].Metadata.Path));
+        Assert.NotEqual(initialSnapshot.RootDirectory!.Files[0].Metadata.Hash, incrementalSnapshot.RootDirectory.Files[0].Metadata.Hash);
     }
         
     [Fact]
@@ -414,7 +395,7 @@ public class SnapshotServiceTests : IDisposable
 
         // Assert
         Assert.Single(incrementalSnapshot.RootDirectory!.Files);
-        Assert.Equal("newfile.txt", Path.GetFileName(incrementalSnapshot.RootDirectory.Files[0].Path));
+        Assert.Equal("newfile.txt", Path.GetFileName(incrementalSnapshot.RootDirectory.Files[0].Metadata.Path));
         Assert.Equal(metadata, incrementalSnapshot.Metadata);
     }
 

--- a/README.md
+++ b/README.md
@@ -66,13 +66,14 @@ await snapshotService.SaveSnapshotAsync(incrementalSnapshot, "incrementalSnapsho
 
 ```csharp
 using FileSnap.Core.Services;
+using FileSnap.Core.Models;
 
 var snapshotService = new SnapshotService(new HashingService());
 var metadata = new Dictionary<string, string>
 {
     { "Author", "John Doe" },
-    { "Description", "Test directory with metadata" }
-};
+    { "Description", "Test file" }
+}
 var snapshot = await snapshotService.CaptureSnapshotWithMetadataAsync("path/to/directory", metadata);
 await snapshotService.SaveSnapshotAsync(snapshot, "snapshot_with_metadata.json");
 ```
@@ -86,10 +87,10 @@ using FileSnap.Core.Models;
 var snapshotService = new SnapshotService(new HashingService());
 var previousSnapshot = await snapshotService.CaptureSnapshotAsync("path/to/directory");
 var metadata = new Dictionary<string, string>
-{
-    { "Author", "Jane Doe" },
-    { "Description", "Incremental snapshot with metadata" }
-};
+    {
+        { "Author", "Jane Doe" },
+        { "Description", "Incremental snapshot with metadata" }
+    }
 // Make some changes to the directory...
 var incrementalSnapshot = await snapshotService.CaptureIncrementalSnapshotWithMetadataAsync("path/to/directory", previousSnapshot, metadata);
 await snapshotService.SaveSnapshotAsync(incrementalSnapshot, "incremental_snapshot_with_metadata.json");
@@ -127,7 +128,7 @@ foreach (var file in difference.DeletedFiles)
 }
 ```
 
-### Analyzing Snapshots
+### Analyzing Snapshot Insights
 
 ```csharp
 using FileSnap.Core.Services;
@@ -143,7 +144,7 @@ Console.WriteLine("File Count: " + insights["FileCount"]);
 Console.WriteLine("Directory Count: " + insights["DirectoryCount"]);
 ```
 
-### Analyzing Snapshots
+### Analyzing Snapshot File and Directory Metadata
 
 ```csharp
 using FileSnap.Core.Services;

--- a/README.md
+++ b/README.md
@@ -62,6 +62,39 @@ var incrementalSnapshot = await snapshotService.CaptureIncrementalSnapshotAsync(
 await snapshotService.SaveSnapshotAsync(incrementalSnapshot, "incrementalSnapshot.json");
 ```
 
+### Capturing a Snapshot with Metadata
+
+```csharp
+using FileSnap.Core.Services;
+
+var snapshotService = new SnapshotService(new HashingService());
+var metadata = new Dictionary<string, string>
+{
+    { "Author", "John Doe" },
+    { "Description", "Test directory with metadata" }
+};
+var snapshot = await snapshotService.CaptureSnapshotWithMetadataAsync("path/to/directory", metadata);
+await snapshotService.SaveSnapshotAsync(snapshot, "snapshot_with_metadata.json");
+```
+
+### Capturing an Incremental Snapshot with Metadata
+
+```csharp
+using FileSnap.Core.Services;
+using FileSnap.Core.Models;
+
+var snapshotService = new SnapshotService(new HashingService());
+var previousSnapshot = await snapshotService.CaptureSnapshotAsync("path/to/directory");
+var metadata = new Dictionary<string, string>
+{
+    { "Author", "Jane Doe" },
+    { "Description", "Incremental snapshot with metadata" }
+};
+// Make some changes to the directory...
+var incrementalSnapshot = await snapshotService.CaptureIncrementalSnapshotWithMetadataAsync("path/to/directory", previousSnapshot, metadata);
+await snapshotService.SaveSnapshotAsync(incrementalSnapshot, "incremental_snapshot_with_metadata.json");
+```
+
 ### Loading and Comparing Snapshots
 
 ```csharp
@@ -78,20 +111,56 @@ var difference = comparisonService.Compare(snapshot1, snapshot2);
 Console.WriteLine("New Files:");
 foreach (var file in difference.NewFiles)
 {
-    Console.WriteLine(file.Path);
+    Console.WriteLine(file.Metadata.Path);
 }
 
 Console.WriteLine("Modified Files:");
 foreach (var (before, after) in difference.ModifiedFiles)
 {
-    Console.WriteLine($"{before.Path} -> {after.Path}");
+    Console.WriteLine($"{before.Metadata.Path} -> {after.Metadata.Path}");
 }
 
 Console.WriteLine("Deleted Files:");
 foreach (var file in difference.DeletedFiles)
 {
-    Console.WriteLine(file.Path);
+    Console.WriteLine(file.Metadata.Path);
 }
+```
+
+### Analyzing Snapshots
+
+```csharp
+using FileSnap.Core.Services;
+
+var snapshotService = new SnapshotService(new HashingService());
+var analysisService = new AnalysisService();
+
+var snapshot = await snapshotService.LoadSnapshotAsync("snapshot.json");
+
+var insights = await analysisService.AnalyzeSnapshotAsync(snapshot);
+
+Console.WriteLine("File Count: " + insights["FileCount"]);
+Console.WriteLine("Directory Count: " + insights["DirectoryCount"]);
+```
+
+### Analyzing Snapshots
+
+```csharp
+using FileSnap.Core.Services;
+using FileSnap.Core.Models;
+
+var snapshotService = new SnapshotService(new HashingService());
+var analysisService = new AnalysisService();
+
+var snapshot = await snapshotService.LoadSnapshotAsync("snapshot.json");
+
+var fileMetadata = analysisService.GetFileMetadata(snapshot.RootDirectory.Files[0]);
+var directoryMetadata = analysisService.GetDirectoryMetadata(snapshot.RootDirectory);
+
+Console.WriteLine("File Path: " + fileMetadata.Path);
+Console.WriteLine("File Size: " + fileMetadata.Size);
+Console.WriteLine("Directory Path: " + directoryMetadata.Path);
+Console.WriteLine("Directory Created At: " + directoryMetadata.CreatedAt);
 ```
 
 ### Restoring a Snapshot

--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ foreach (var file in difference.DeletedFiles)
 }
 ```
 
-### Analyzing Snapshot Insights
+### Analyzing a Snapshot
 
 ```csharp
 using FileSnap.Core.Services;


### PR DESCRIPTION
Add methods to AnalysisService for retrieving metadata and analyzing distributions.

* **AnalysisService.cs**
  - Add `GetFileMetadata` method to retrieve metadata for a given file
  - Add `GetDirectoryMetadata` method to retrieve metadata for a given directory
  - Add `GetFileSizeDistribution` method to analyze file size distribution in the snapshot
  - Add `GetDirectorySizeDistribution` method to analyze directory size distribution in the snapshot
  - Add `GetFileAttributeDistribution` method to analyze file attribute distribution in the snapshot
  - Update `TraverseDirectory` methods to use metadata properties
 
* **FileMetadata.cs**
  - Define class `FileMetadata` with properties for file attributes, size, and timestamps

* **DirectoryMetadata.cs**
  - Define class `DirectoryMetadata` with properties for directory attributes and timestamps

* **FileSnapshot.cs**
  - Replace individual metadata properties with a `FileMetadata` property

* **DirectorySnapshot.cs**
  - Replace individual metadata properties with a `DirectoryMetadata` property
