### PR TITLE
Add file watcher to FileSnap library

### DIFF
--- a/FileSnap.Core/Models/DirectoryMetadata.cs
+++ b/FileSnap.Core/Models/DirectoryMetadata.cs
@@ -34,4 +34,35 @@ public class DirectoryMetadata
     /// Gets or sets additional metadata for the directory.
     /// </summary>
     public Dictionary<string, string>? AdditionalMetadata { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user who made the change.
+    /// </summary>
+    public string? User { get; set; }
+
+    /// <summary>
+    /// Gets or sets the process that triggered the event.
+    /// </summary>
+    public string? Process { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp of the event.
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="DirectoryMetadata"/> class.
+    /// </summary>
+    public DirectoryMetadata()
+    {
+        Path = string.Empty;
+        CreatedAt = DateTime.MinValue;
+        Attributes = FileAttributes.Directory;
+        LastModified = DateTime.MinValue;
+        Size = 0;
+        AdditionalMetadata = new Dictionary<string, string>();
+        User = string.Empty;
+        Process = string.Empty;
+        Timestamp = DateTime.MinValue;
+    }
 }

--- a/FileSnap.Core/Models/FileMetadata.cs
+++ b/FileSnap.Core/Models/FileMetadata.cs
@@ -39,4 +39,36 @@ public class FileMetadata
     /// Gets or sets additional metadata for the file.
     /// </summary>
     public Dictionary<string, string>? AdditionalMetadata { get; set; }
+
+    /// <summary>
+    /// Gets or sets the user who made the change.
+    /// </summary>
+    public string? User { get; set; }
+
+    /// <summary>
+    /// Gets or sets the process that triggered the event.
+    /// </summary>
+    public string? Process { get; set; }
+
+    /// <summary>
+    /// Gets or sets the timestamp of the event.
+    /// </summary>
+    public DateTime Timestamp { get; set; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="FileMetadata"/> class.
+    /// </summary>
+    public FileMetadata()
+    {
+        Path = string.Empty;
+        Size = 0;
+        Hash = string.Empty;
+        LastModified = DateTime.MinValue;
+        CreatedAt = DateTime.MinValue;
+        Attributes = FileAttributes.Normal;
+        AdditionalMetadata = new Dictionary<string, string>();
+        User = string.Empty;
+        Process = string.Empty;
+        Timestamp = DateTime.MinValue;
+    }
 }

--- a/FileSnap.Core/Services/FileWatcherService.cs
+++ b/FileSnap.Core/Services/FileWatcherService.cs
@@ -1,244 +1,239 @@
-using System;
-using System.Collections.Generic;
-using System.Diagnostics;
-using System.IO;
+using FileSnap.Core.Models;
 using System.Runtime.InteropServices;
-using System.Threading.Tasks;
 
-namespace FileSnap.Core.Services
+namespace FileSnap.Core.Services;
+
+public class FileWatcherService : IFileWatcherService
 {
-    public class FileWatcherService : IFileWatcherService
+    private readonly List<FileSystemWatcher> _watchers = new();
+    private EventFilterOptions _filterOptions = new();
+    private bool _treatFilePermissionChangesAsSeparateEvent;
+    private bool _followSymbolicLinks;
+    private bool _treatFileRenamesAsSeparateEvent;
+    private bool _treatFileDeletionsAsSeparateEvent;
+    private bool _treatFileMovesAsSeparateEvent;
+    private bool _treatFileAttributeChangesAsSeparateEvent;
+    private bool _treatFileCreationEventsAsSeparateEvent;
+    private bool _treatFileModificationsAsSeparateEvent;
+    private bool _treatFileSystemMountEventsAsSeparateEvent;
+    private bool _supportNetworkFileSystems;
+
+    public void StartWatching(string path)
     {
-        private readonly List<FileSystemWatcher> _watchers = new();
-        private EventFilterOptions _filterOptions = new();
-        private bool _treatFilePermissionChangesAsSeparateEvent;
-        private bool _followSymbolicLinks;
-        private bool _treatFileRenamesAsSeparateEvent;
-        private bool _treatFileDeletionsAsSeparateEvent;
-        private bool _treatFileMovesAsSeparateEvent;
-        private bool _treatFileAttributeChangesAsSeparateEvent;
-        private bool _treatFileCreationEventsAsSeparateEvent;
-        private bool _treatFileModificationsAsSeparateEvent;
-        private bool _treatFileSystemMountEventsAsSeparateEvent;
-        private bool _supportNetworkFileSystems;
-
-        public void StartWatching(string path)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
-            {
-                StartWindowsWatcher(path);
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-            {
-                StartMacOSWatcher(path);
-            }
-            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
-            {
-                StartLinuxWatcher(path);
-            }
-            else
-            {
-                throw new PlatformNotSupportedException("Unsupported platform");
-            }
+            StartWindowsWatcher(path);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+        {
+            StartMacOSWatcher(path);
+        }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            StartLinuxWatcher(path);
+        }
+        else
+        {
+            throw new PlatformNotSupportedException("Unsupported platform");
+        }
+    }
+
+    public void StopWatching()
+    {
+        foreach (var watcher in _watchers)
+        {
+            watcher.Dispose();
+        }
+        _watchers.Clear();
+    }
+
+    public void ConfigureFilePermissionChanges(bool treatAsSeparateEvent)
+    {
+        _treatFilePermissionChangesAsSeparateEvent = treatAsSeparateEvent;
+    }
+
+    public void ConfigureSymbolicLinks(bool followSymbolicLinks)
+    {
+        _followSymbolicLinks = followSymbolicLinks;
+    }
+
+    public void ConfigureFileRenames(bool treatAsSeparateEvent)
+    {
+        _treatFileRenamesAsSeparateEvent = treatAsSeparateEvent;
+    }
+
+    public void ConfigureFileDeletions(bool treatAsSeparateEvent)
+    {
+        _treatFileDeletionsAsSeparateEvent = treatAsSeparateEvent;
+    }
+
+    public void ConfigureFileMoves(bool treatAsSeparateEvent)
+    {
+        _treatFileMovesAsSeparateEvent = treatAsSeparateEvent;
+    }
+
+    public void ConfigureFileAttributeChanges(bool treatAsSeparateEvent)
+    {
+        _treatFileAttributeChangesAsSeparateEvent = treatAsSeparateEvent;
+    }
+
+    public void ConfigureFileCreationEvents(bool treatAsSeparateEvent)
+    {
+        _treatFileCreationEventsAsSeparateEvent = treatAsSeparateEvent;
+    }
+
+    public void ConfigureFileModifications(bool treatAsSeparateEvent)
+    {
+        _treatFileModificationsAsSeparateEvent = treatAsSeparateEvent;
+    }
+
+    public void ConfigureEventFiltering(EventFilterOptions filterOptions)
+    {
+        _filterOptions = filterOptions;
+    }
+
+    public void ConfigureFileSystemMountEvents(bool treatAsSeparateEvent)
+    {
+        _treatFileSystemMountEventsAsSeparateEvent = treatAsSeparateEvent;
+    }
+
+    public void ConfigureNetworkFileSystems(bool supportNetworkFileSystems)
+    {
+        _supportNetworkFileSystems = supportNetworkFileSystems;
+    }
+
+    public FileMetadata GetFileMetadata(string path)
+    {
+        var fileInfo = new FileInfo(path);
+        var metadata = new FileMetadata
+        {
+            Path = path,
+            Size = fileInfo.Length,
+            LastModified = fileInfo.LastWriteTimeUtc,
+            CreatedAt = fileInfo.CreationTimeUtc,
+            Attributes = fileInfo.Attributes,
+            User = GetUser(fileInfo),
+            Process = GetProcess(fileInfo),
+            Timestamp = DateTime.UtcNow
+        };
+
+        return metadata;
+    }
+
+    private void StartWindowsWatcher(string path)
+    {
+        var watcher = new FileSystemWatcher(path)
+        {
+            IncludeSubdirectories = true,
+            NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.Attributes |
+                           NotifyFilters.Size | NotifyFilters.LastWrite | NotifyFilters.LastAccess |
+                           NotifyFilters.CreationTime | NotifyFilters.Security
+        };
+
+        watcher.Changed += OnChanged;
+        watcher.Created += OnCreated;
+        watcher.Deleted += OnDeleted;
+        watcher.Renamed += OnRenamed;
+        watcher.Error += OnError;
+
+        watcher.EnableRaisingEvents = true;
+        _watchers.Add(watcher);
+    }
+
+    private void StartMacOSWatcher(string path)
+    {
+        // Implement SFEvents-based watcher for MacOS
+        throw new NotImplementedException("MacOS watcher is not implemented yet.");
+    }
+
+    private void StartLinuxWatcher(string path)
+    {
+        // Implement inotify-based watcher for Linux
+        throw new NotImplementedException("Linux watcher is not implemented yet.");
+    }
+
+    private void OnChanged(object sender, FileSystemEventArgs e)
+    {
+        if (ShouldFilterEvent(e.FullPath))
+        {
+            return;
         }
 
-        public void StopWatching()
+        var metadata = GetFileMetadata(e.FullPath);
+        // Handle file changed event
+    }
+
+    private void OnCreated(object sender, FileSystemEventArgs e)
+    {
+        if (ShouldFilterEvent(e.FullPath))
         {
-            foreach (var watcher in _watchers)
-            {
-                watcher.Dispose();
-            }
-            _watchers.Clear();
+            return;
         }
 
-        public void ConfigureFilePermissionChanges(bool treatAsSeparateEvent)
+        var metadata = GetFileMetadata(e.FullPath);
+        // Handle file created event
+    }
+
+    private void OnDeleted(object sender, FileSystemEventArgs e)
+    {
+        if (ShouldFilterEvent(e.FullPath))
         {
-            _treatFilePermissionChangesAsSeparateEvent = treatAsSeparateEvent;
+            return;
         }
 
-        public void ConfigureSymbolicLinks(bool followSymbolicLinks)
+        var metadata = GetFileMetadata(e.FullPath);
+        // Handle file deleted event
+    }
+
+    private void OnRenamed(object sender, RenamedEventArgs e)
+    {
+        if (ShouldFilterEvent(e.FullPath))
         {
-            _followSymbolicLinks = followSymbolicLinks;
+            return;
         }
 
-        public void ConfigureFileRenames(bool treatAsSeparateEvent)
+        var metadata = GetFileMetadata(e.FullPath);
+        // Handle file renamed event
+    }
+
+    private void OnError(object sender, ErrorEventArgs e)
+    {
+        // Handle error event
+    }
+
+    private bool ShouldFilterEvent(string path)
+    {
+        var extension = Path.GetExtension(path);
+        var directory = Path.GetDirectoryName(path);
+        var fileName = Path.GetFileName(path);
+
+        if (_filterOptions.FileExtensions.Count > 0 && !_filterOptions.FileExtensions.Contains(extension))
         {
-            _treatFileRenamesAsSeparateEvent = treatAsSeparateEvent;
+            return true;
         }
 
-        public void ConfigureFileDeletions(bool treatAsSeparateEvent)
+        if (_filterOptions.Directories.Count > 0 && !_filterOptions.Directories.Contains(directory!))
         {
-            _treatFileDeletionsAsSeparateEvent = treatAsSeparateEvent;
+            return true;
         }
 
-        public void ConfigureFileMoves(bool treatAsSeparateEvent)
+        if (_filterOptions.FileNames.Count > 0 && !_filterOptions.FileNames.Contains(fileName))
         {
-            _treatFileMovesAsSeparateEvent = treatAsSeparateEvent;
+            return true;
         }
 
-        public void ConfigureFileAttributeChanges(bool treatAsSeparateEvent)
-        {
-            _treatFileAttributeChangesAsSeparateEvent = treatAsSeparateEvent;
-        }
+        return false;
+    }
 
-        public void ConfigureFileCreationEvents(bool treatAsSeparateEvent)
-        {
-            _treatFileCreationEventsAsSeparateEvent = treatAsSeparateEvent;
-        }
+    private string GetUser(FileInfo fileInfo)
+    {
+        // Implement logic to get the user who made the change
+        return "Unknown";
+    }
 
-        public void ConfigureFileModifications(bool treatAsSeparateEvent)
-        {
-            _treatFileModificationsAsSeparateEvent = treatAsSeparateEvent;
-        }
-
-        public void ConfigureEventFiltering(EventFilterOptions filterOptions)
-        {
-            _filterOptions = filterOptions;
-        }
-
-        public void ConfigureFileSystemMountEvents(bool treatAsSeparateEvent)
-        {
-            _treatFileSystemMountEventsAsSeparateEvent = treatAsSeparateEvent;
-        }
-
-        public void ConfigureNetworkFileSystems(bool supportNetworkFileSystems)
-        {
-            _supportNetworkFileSystems = supportNetworkFileSystems;
-        }
-
-        private void StartWindowsWatcher(string path)
-        {
-            var watcher = new FileSystemWatcher(path)
-            {
-                IncludeSubdirectories = true,
-                NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.Attributes |
-                               NotifyFilters.Size | NotifyFilters.LastWrite | NotifyFilters.LastAccess |
-                               NotifyFilters.CreationTime | NotifyFilters.Security
-            };
-
-            watcher.Changed += OnChanged;
-            watcher.Created += OnCreated;
-            watcher.Deleted += OnDeleted;
-            watcher.Renamed += OnRenamed;
-            watcher.Error += OnError;
-
-            watcher.EnableRaisingEvents = true;
-            _watchers.Add(watcher);
-        }
-
-        private void StartMacOSWatcher(string path)
-        {
-            // Implement SFEvents-based watcher for MacOS
-            throw new NotImplementedException("MacOS watcher is not implemented yet.");
-        }
-
-        private void StartLinuxWatcher(string path)
-        {
-            // Implement inotify-based watcher for Linux
-            throw new NotImplementedException("Linux watcher is not implemented yet.");
-        }
-
-        private void OnChanged(object sender, FileSystemEventArgs e)
-        {
-            if (ShouldFilterEvent(e.FullPath))
-            {
-                return;
-            }
-
-            var metadata = GetFileMetadata(e.FullPath);
-            // Handle file changed event
-        }
-
-        private void OnCreated(object sender, FileSystemEventArgs e)
-        {
-            if (ShouldFilterEvent(e.FullPath))
-            {
-                return;
-            }
-
-            var metadata = GetFileMetadata(e.FullPath);
-            // Handle file created event
-        }
-
-        private void OnDeleted(object sender, FileSystemEventArgs e)
-        {
-            if (ShouldFilterEvent(e.FullPath))
-            {
-                return;
-            }
-
-            var metadata = GetFileMetadata(e.FullPath);
-            // Handle file deleted event
-        }
-
-        private void OnRenamed(object sender, RenamedEventArgs e)
-        {
-            if (ShouldFilterEvent(e.FullPath))
-            {
-                return;
-            }
-
-            var metadata = GetFileMetadata(e.FullPath);
-            // Handle file renamed event
-        }
-
-        private void OnError(object sender, ErrorEventArgs e)
-        {
-            // Handle error event
-        }
-
-        private bool ShouldFilterEvent(string path)
-        {
-            var extension = Path.GetExtension(path);
-            var directory = Path.GetDirectoryName(path);
-            var fileName = Path.GetFileName(path);
-
-            if (_filterOptions.FileExtensions.Count > 0 && !_filterOptions.FileExtensions.Contains(extension))
-            {
-                return true;
-            }
-
-            if (_filterOptions.Directories.Count > 0 && !_filterOptions.Directories.Contains(directory))
-            {
-                return true;
-            }
-
-            if (_filterOptions.FileNames.Count > 0 && !_filterOptions.FileNames.Contains(fileName))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        private FileMetadata GetFileMetadata(string path)
-        {
-            var fileInfo = new FileInfo(path);
-            var metadata = new FileMetadata
-            {
-                Path = path,
-                Size = fileInfo.Length,
-                LastModified = fileInfo.LastWriteTimeUtc,
-                CreatedAt = fileInfo.CreationTimeUtc,
-                Attributes = fileInfo.Attributes,
-                User = GetUser(fileInfo),
-                Process = GetProcess(fileInfo),
-                Timestamp = DateTime.UtcNow
-            };
-
-            return metadata;
-        }
-
-        private string GetUser(FileInfo fileInfo)
-        {
-            // Implement logic to get the user who made the change
-            return "Unknown";
-        }
-
-        private string GetProcess(FileInfo fileInfo)
-        {
-            // Implement logic to get the process that triggered the event
-            return "Unknown";
-        }
+    private string GetProcess(FileInfo fileInfo)
+    {
+        // Implement logic to get the process that triggered the event
+        return "Unknown";
     }
 }

--- a/FileSnap.Core/Services/FileWatcherService.cs
+++ b/FileSnap.Core/Services/FileWatcherService.cs
@@ -1,0 +1,244 @@
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Runtime.InteropServices;
+using System.Threading.Tasks;
+
+namespace FileSnap.Core.Services
+{
+    public class FileWatcherService : IFileWatcherService
+    {
+        private readonly List<FileSystemWatcher> _watchers = new();
+        private EventFilterOptions _filterOptions = new();
+        private bool _treatFilePermissionChangesAsSeparateEvent;
+        private bool _followSymbolicLinks;
+        private bool _treatFileRenamesAsSeparateEvent;
+        private bool _treatFileDeletionsAsSeparateEvent;
+        private bool _treatFileMovesAsSeparateEvent;
+        private bool _treatFileAttributeChangesAsSeparateEvent;
+        private bool _treatFileCreationEventsAsSeparateEvent;
+        private bool _treatFileModificationsAsSeparateEvent;
+        private bool _treatFileSystemMountEventsAsSeparateEvent;
+        private bool _supportNetworkFileSystems;
+
+        public void StartWatching(string path)
+        {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            {
+                StartWindowsWatcher(path);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
+            {
+                StartMacOSWatcher(path);
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+            {
+                StartLinuxWatcher(path);
+            }
+            else
+            {
+                throw new PlatformNotSupportedException("Unsupported platform");
+            }
+        }
+
+        public void StopWatching()
+        {
+            foreach (var watcher in _watchers)
+            {
+                watcher.Dispose();
+            }
+            _watchers.Clear();
+        }
+
+        public void ConfigureFilePermissionChanges(bool treatAsSeparateEvent)
+        {
+            _treatFilePermissionChangesAsSeparateEvent = treatAsSeparateEvent;
+        }
+
+        public void ConfigureSymbolicLinks(bool followSymbolicLinks)
+        {
+            _followSymbolicLinks = followSymbolicLinks;
+        }
+
+        public void ConfigureFileRenames(bool treatAsSeparateEvent)
+        {
+            _treatFileRenamesAsSeparateEvent = treatAsSeparateEvent;
+        }
+
+        public void ConfigureFileDeletions(bool treatAsSeparateEvent)
+        {
+            _treatFileDeletionsAsSeparateEvent = treatAsSeparateEvent;
+        }
+
+        public void ConfigureFileMoves(bool treatAsSeparateEvent)
+        {
+            _treatFileMovesAsSeparateEvent = treatAsSeparateEvent;
+        }
+
+        public void ConfigureFileAttributeChanges(bool treatAsSeparateEvent)
+        {
+            _treatFileAttributeChangesAsSeparateEvent = treatAsSeparateEvent;
+        }
+
+        public void ConfigureFileCreationEvents(bool treatAsSeparateEvent)
+        {
+            _treatFileCreationEventsAsSeparateEvent = treatAsSeparateEvent;
+        }
+
+        public void ConfigureFileModifications(bool treatAsSeparateEvent)
+        {
+            _treatFileModificationsAsSeparateEvent = treatAsSeparateEvent;
+        }
+
+        public void ConfigureEventFiltering(EventFilterOptions filterOptions)
+        {
+            _filterOptions = filterOptions;
+        }
+
+        public void ConfigureFileSystemMountEvents(bool treatAsSeparateEvent)
+        {
+            _treatFileSystemMountEventsAsSeparateEvent = treatAsSeparateEvent;
+        }
+
+        public void ConfigureNetworkFileSystems(bool supportNetworkFileSystems)
+        {
+            _supportNetworkFileSystems = supportNetworkFileSystems;
+        }
+
+        private void StartWindowsWatcher(string path)
+        {
+            var watcher = new FileSystemWatcher(path)
+            {
+                IncludeSubdirectories = true,
+                NotifyFilter = NotifyFilters.FileName | NotifyFilters.DirectoryName | NotifyFilters.Attributes |
+                               NotifyFilters.Size | NotifyFilters.LastWrite | NotifyFilters.LastAccess |
+                               NotifyFilters.CreationTime | NotifyFilters.Security
+            };
+
+            watcher.Changed += OnChanged;
+            watcher.Created += OnCreated;
+            watcher.Deleted += OnDeleted;
+            watcher.Renamed += OnRenamed;
+            watcher.Error += OnError;
+
+            watcher.EnableRaisingEvents = true;
+            _watchers.Add(watcher);
+        }
+
+        private void StartMacOSWatcher(string path)
+        {
+            // Implement SFEvents-based watcher for MacOS
+            throw new NotImplementedException("MacOS watcher is not implemented yet.");
+        }
+
+        private void StartLinuxWatcher(string path)
+        {
+            // Implement inotify-based watcher for Linux
+            throw new NotImplementedException("Linux watcher is not implemented yet.");
+        }
+
+        private void OnChanged(object sender, FileSystemEventArgs e)
+        {
+            if (ShouldFilterEvent(e.FullPath))
+            {
+                return;
+            }
+
+            var metadata = GetFileMetadata(e.FullPath);
+            // Handle file changed event
+        }
+
+        private void OnCreated(object sender, FileSystemEventArgs e)
+        {
+            if (ShouldFilterEvent(e.FullPath))
+            {
+                return;
+            }
+
+            var metadata = GetFileMetadata(e.FullPath);
+            // Handle file created event
+        }
+
+        private void OnDeleted(object sender, FileSystemEventArgs e)
+        {
+            if (ShouldFilterEvent(e.FullPath))
+            {
+                return;
+            }
+
+            var metadata = GetFileMetadata(e.FullPath);
+            // Handle file deleted event
+        }
+
+        private void OnRenamed(object sender, RenamedEventArgs e)
+        {
+            if (ShouldFilterEvent(e.FullPath))
+            {
+                return;
+            }
+
+            var metadata = GetFileMetadata(e.FullPath);
+            // Handle file renamed event
+        }
+
+        private void OnError(object sender, ErrorEventArgs e)
+        {
+            // Handle error event
+        }
+
+        private bool ShouldFilterEvent(string path)
+        {
+            var extension = Path.GetExtension(path);
+            var directory = Path.GetDirectoryName(path);
+            var fileName = Path.GetFileName(path);
+
+            if (_filterOptions.FileExtensions.Count > 0 && !_filterOptions.FileExtensions.Contains(extension))
+            {
+                return true;
+            }
+
+            if (_filterOptions.Directories.Count > 0 && !_filterOptions.Directories.Contains(directory))
+            {
+                return true;
+            }
+
+            if (_filterOptions.FileNames.Count > 0 && !_filterOptions.FileNames.Contains(fileName))
+            {
+                return true;
+            }
+
+            return false;
+        }
+
+        private FileMetadata GetFileMetadata(string path)
+        {
+            var fileInfo = new FileInfo(path);
+            var metadata = new FileMetadata
+            {
+                Path = path,
+                Size = fileInfo.Length,
+                LastModified = fileInfo.LastWriteTimeUtc,
+                CreatedAt = fileInfo.CreationTimeUtc,
+                Attributes = fileInfo.Attributes,
+                User = GetUser(fileInfo),
+                Process = GetProcess(fileInfo),
+                Timestamp = DateTime.UtcNow
+            };
+
+            return metadata;
+        }
+
+        private string GetUser(FileInfo fileInfo)
+        {
+            // Implement logic to get the user who made the change
+            return "Unknown";
+        }
+
+        private string GetProcess(FileInfo fileInfo)
+        {
+            // Implement logic to get the process that triggered the event
+            return "Unknown";
+        }
+    }
+}

--- a/FileSnap.Core/Services/IFileWatcherService.cs
+++ b/FileSnap.Core/Services/IFileWatcherService.cs
@@ -1,0 +1,102 @@
+namespace FileSnap.Core.Services;
+
+public interface IFileWatcherService
+{
+    /// <summary>
+    /// Starts the file watcher for the specified path.
+    /// </summary>
+    /// <param name="path">The path to watch for file system changes.</param>
+    void StartWatching(string path);
+
+    /// <summary>
+    /// Stops the file watcher.
+    /// </summary>
+    void StopWatching();
+
+    /// <summary>
+    /// Configures the file watcher to treat file permission changes as separate events or part of other events.
+    /// </summary>
+    /// <param name="treatAsSeparateEvent">True to treat file permission changes as separate events, false to treat them as part of other events.</param>
+    void ConfigureFilePermissionChanges(bool treatAsSeparateEvent);
+
+    /// <summary>
+    /// Configures the file watcher to treat symbolic links as regular files or directories or to follow them and capture the target content.
+    /// </summary>
+    /// <param name="followSymbolicLinks">True to follow symbolic links and capture the target content, false to treat them as regular files or directories.</param>
+    void ConfigureSymbolicLinks(bool followSymbolicLinks);
+
+    /// <summary>
+    /// Configures the file watcher to treat file renames as separate events or as a single event.
+    /// </summary>
+    /// <param name="treatAsSeparateEvent">True to treat file renames as separate events, false to treat them as a single event.</param>
+    void ConfigureFileRenames(bool treatAsSeparateEvent);
+
+    /// <summary>
+    /// Configures the file watcher to treat file deletions as separate events or part of other events.
+    /// </summary>
+    /// <param name="treatAsSeparateEvent">True to treat file deletions as separate events, false to treat them as part of other events.</param>
+    void ConfigureFileDeletions(bool treatAsSeparateEvent);
+
+    /// <summary>
+    /// Configures the file watcher to treat file moves as separate events (delete and create) or as a single move event.
+    /// </summary>
+    /// <param name="treatAsSeparateEvent">True to treat file moves as separate events, false to treat them as a single move event.</param>
+    void ConfigureFileMoves(bool treatAsSeparateEvent);
+
+    /// <summary>
+    /// Configures the file watcher to treat file attribute changes as separate events or part of other events.
+    /// </summary>
+    /// <param name="treatAsSeparateEvent">True to treat file attribute changes as separate events, false to treat them as part of other events.</param>
+    void ConfigureFileAttributeChanges(bool treatAsSeparateEvent);
+
+    /// <summary>
+    /// Configures the file watcher to treat file creation events as separate events or part of other events.
+    /// </summary>
+    /// <param name="treatAsSeparateEvent">True to treat file creation events as separate events, false to treat them as part of other events.</param>
+    void ConfigureFileCreationEvents(bool treatAsSeparateEvent);
+
+    /// <summary>
+    /// Configures the file watcher to treat file modifications as separate events or part of other events.
+    /// </summary>
+    /// <param name="treatAsSeparateEvent">True to treat file modifications as separate events, false to treat them as part of other events.</param>
+    void ConfigureFileModifications(bool treatAsSeparateEvent);
+
+    /// <summary>
+    /// Configures the file watcher to filter events based on file extensions, directories, or specific file names.
+    /// </summary>
+    /// <param name="filterOptions">The filter options to apply.</param>
+    void ConfigureEventFiltering(EventFilterOptions filterOptions);
+
+    /// <summary>
+    /// Configures the file watcher to treat file system mount and unmount events as separate events or part of other events.
+    /// </summary>
+    /// <param name="treatAsSeparateEvent">True to treat file system mount and unmount events as separate events, false to treat them as part of other events.</param>
+    void ConfigureFileSystemMountEvents(bool treatAsSeparateEvent);
+
+    /// <summary>
+    /// Configures the file watcher to support network file systems.
+    /// </summary>
+    /// <param name="supportNetworkFileSystems">True to support network file systems, false otherwise.</param>
+    void ConfigureNetworkFileSystems(bool supportNetworkFileSystems);
+}
+
+/// <summary>
+/// Represents the options for filtering file system events.
+/// </summary>
+public class EventFilterOptions
+{
+    /// <summary>
+    /// Gets or sets the file extensions to include in the event filtering.
+    /// </summary>
+    public List<string> FileExtensions { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the directories to include in the event filtering.
+    /// </summary>
+    public List<string> Directories { get; set; } = new();
+
+    /// <summary>
+    /// Gets or sets the specific file names to include in the event filtering.
+    /// </summary>
+    public List<string> FileNames { get; set; } = new();
+}

--- a/FileSnap.Core/Services/ISnapshotService.cs
+++ b/FileSnap.Core/Services/ISnapshotService.cs
@@ -22,7 +22,6 @@ public interface ISnapshotService
     /// <returns>A task that represents the asynchronous operation. The task result contains the captured incremental snapshot.</returns>
     Task<SystemSnapshot> CaptureIncrementalSnapshotAsync(string path, SystemSnapshot previousSnapshot);
 
-
     /// <summary>
     /// Loads a snapshot from the specified path.
     /// </summary>
@@ -34,7 +33,18 @@ public interface ISnapshotService
     /// Saves the snapshot to the specified output path.
     /// </summary>
     /// <param name="snapshot">The snapshot to save.</param>
-    /// <param name="outputPath">The output path to save the snapshot to.</param>
+    /// <param="outputPath">The output path to save the snapshot to.</param>
     /// <returns>A task that represents the asynchronous operation.</returns>
     Task SaveSnapshotAsync(SystemSnapshot snapshot, string outputPath);
+
+    /// <summary>
+    /// Starts the file watcher for the specified path.
+    /// </summary>
+    /// <param name="path">The path to watch for file system changes.</param>
+    void StartFileWatcher(string path);
+
+    /// <summary>
+    /// Stops the file watcher.
+    /// </summary>
+    void StopFileWatcher();
 }

--- a/FileSnap.Core/Services/SnapshotService.cs
+++ b/FileSnap.Core/Services/SnapshotService.cs
@@ -17,6 +17,7 @@ public class SnapshotService : ISnapshotService
     private readonly ICompressionService _compressionService;
     private readonly JsonSerializerOptions _jsonSerializerOptions;
     private readonly bool _isCompressionEnabled;
+    private readonly IFileWatcherService _fileWatcherService;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="SnapshotService"/> class with the default hashing service.
@@ -59,6 +60,7 @@ public class SnapshotService : ISnapshotService
         _compressionService = compressionService ?? new BrotliCompressionService();
         _jsonSerializerOptions = new JsonSerializerOptions { WriteIndented = true };
         _isCompressionEnabled = isCompressionEnabled;
+        _fileWatcherService = new FileWatcherService();
     }
 
     /// <summary>
@@ -313,5 +315,22 @@ public class SnapshotService : ISnapshotService
         });
 
         Parallel.ForEach(directorySnapshot.Directories, DecompressContent);
+    }
+
+    /// <summary>
+    /// Starts the file watcher for the specified path.
+    /// </summary>
+    /// <param name="path">The path to watch for file system changes.</param>
+    public void StartFileWatcher(string path)
+    {
+        _fileWatcherService.StartWatching(path);
+    }
+
+    /// <summary>
+    /// Stops the file watcher.
+    /// </summary>
+    public void StopFileWatcher()
+    {
+        _fileWatcherService.StopWatching();
     }
 }

--- a/FileSnap.Tests/FileSnap.Tests.csproj
+++ b/FileSnap.Tests/FileSnap.Tests.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit" Version="2.9.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>

--- a/FileSnap.Tests/FileWatcherServiceTests.cs
+++ b/FileSnap.Tests/FileWatcherServiceTests.cs
@@ -1,0 +1,177 @@
+using FileSnap.Core.Services;
+using FileSnap.Core.Models;
+using Moq;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Runtime.InteropServices;
+using Xunit;
+
+namespace FileSnap.Tests
+{
+    public class FileWatcherServiceTests
+    {
+        private readonly Mock<IFileWatcherService> _fileWatcherServiceMock;
+        private readonly string _testDirectory;
+
+        public FileWatcherServiceTests()
+        {
+            _fileWatcherServiceMock = new Mock<IFileWatcherService>();
+            _testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+            Directory.CreateDirectory(_testDirectory);
+        }
+
+        [Fact]
+        public void StartWatching_ShouldStartWatcher()
+        {
+            _fileWatcherServiceMock.Object.StartWatching(_testDirectory);
+            _fileWatcherServiceMock.Verify(service => service.StartWatching(_testDirectory), Times.Once);
+        }
+
+        [Fact]
+        public void StopWatching_ShouldStopWatcher()
+        {
+            _fileWatcherServiceMock.Object.StopWatching();
+            _fileWatcherServiceMock.Verify(service => service.StopWatching(), Times.Once);
+        }
+
+        [Fact]
+        public void ConfigureFilePermissionChanges_ShouldSetOption()
+        {
+            _fileWatcherServiceMock.Object.ConfigureFilePermissionChanges(true);
+            _fileWatcherServiceMock.Verify(service => service.ConfigureFilePermissionChanges(true), Times.Once);
+        }
+
+        [Fact]
+        public void ConfigureSymbolicLinks_ShouldSetOption()
+        {
+            _fileWatcherServiceMock.Object.ConfigureSymbolicLinks(true);
+            _fileWatcherServiceMock.Verify(service => service.ConfigureSymbolicLinks(true), Times.Once);
+        }
+
+        [Fact]
+        public void ConfigureFileRenames_ShouldSetOption()
+        {
+            _fileWatcherServiceMock.Object.ConfigureFileRenames(true);
+            _fileWatcherServiceMock.Verify(service => service.ConfigureFileRenames(true), Times.Once);
+        }
+
+        [Fact]
+        public void ConfigureFileDeletions_ShouldSetOption()
+        {
+            _fileWatcherServiceMock.Object.ConfigureFileDeletions(true);
+            _fileWatcherServiceMock.Verify(service => service.ConfigureFileDeletions(true), Times.Once);
+        }
+
+        [Fact]
+        public void ConfigureFileMoves_ShouldSetOption()
+        {
+            _fileWatcherServiceMock.Object.ConfigureFileMoves(true);
+            _fileWatcherServiceMock.Verify(service => service.ConfigureFileMoves(true), Times.Once);
+        }
+
+        [Fact]
+        public void ConfigureFileAttributeChanges_ShouldSetOption()
+        {
+            _fileWatcherServiceMock.Object.ConfigureFileAttributeChanges(true);
+            _fileWatcherServiceMock.Verify(service => service.ConfigureFileAttributeChanges(true), Times.Once);
+        }
+
+        [Fact]
+        public void ConfigureFileCreationEvents_ShouldSetOption()
+        {
+            _fileWatcherServiceMock.Object.ConfigureFileCreationEvents(true);
+            _fileWatcherServiceMock.Verify(service => service.ConfigureFileCreationEvents(true), Times.Once);
+        }
+
+        [Fact]
+        public void ConfigureFileModifications_ShouldSetOption()
+        {
+            _fileWatcherServiceMock.Object.ConfigureFileModifications(true);
+            _fileWatcherServiceMock.Verify(service => service.ConfigureFileModifications(true), Times.Once);
+        }
+
+        [Fact]
+        public void ConfigureEventFiltering_ShouldSetFilterOptions()
+        {
+            var filterOptions = new EventFilterOptions
+            {
+                FileExtensions = new List<string> { ".txt" },
+                Directories = new List<string> { _testDirectory },
+                FileNames = new List<string> { "test.txt" }
+            };
+
+            _fileWatcherServiceMock.Object.ConfigureEventFiltering(filterOptions);
+            _fileWatcherServiceMock.Verify(service => service.ConfigureEventFiltering(filterOptions), Times.Once);
+        }
+
+        [Fact]
+        public void FileWatcher_ShouldCaptureMetadata()
+        {
+            var fileWatcherService = new FileWatcherService();
+            var testFilePath = Path.Combine(_testDirectory, "test.txt");
+            File.WriteAllText(testFilePath, "Test content");
+
+            fileWatcherService.StartWatching(_testDirectory);
+
+            var metadata = fileWatcherService.GetFileMetadata(testFilePath);
+
+            Assert.Equal(testFilePath, metadata.Path);
+            Assert.Equal("Test content".Length, metadata.Size);
+            Assert.Equal(File.GetLastWriteTimeUtc(testFilePath), metadata.LastModified);
+            Assert.Equal(File.GetCreationTimeUtc(testFilePath), metadata.CreatedAt);
+            Assert.Equal(FileAttributes.Normal, metadata.Attributes);
+            Assert.Equal("Unknown", metadata.User);
+            Assert.Equal("Unknown", metadata.Process);
+            Assert.Equal(DateTime.UtcNow.Date, metadata.Timestamp.Date);
+
+            fileWatcherService.StopWatching();
+        }
+
+        [Fact]
+        public void ConfigureFileSystemMountEvents_ShouldSetOption()
+        {
+            _fileWatcherServiceMock.Object.ConfigureFileSystemMountEvents(true);
+            _fileWatcherServiceMock.Verify(service => service.ConfigureFileSystemMountEvents(true), Times.Once);
+        }
+
+        [Fact]
+        public void ConfigureNetworkFileSystems_ShouldSetOption()
+        {
+            _fileWatcherServiceMock.Object.ConfigureNetworkFileSystems(true);
+            _fileWatcherServiceMock.Verify(service => service.ConfigureNetworkFileSystems(true), Times.Once);
+        }
+
+        [Fact]
+        public void FileWatcher_ShouldFilterEvents()
+        {
+            var fileWatcherService = new FileWatcherService();
+            var filterOptions = new EventFilterOptions
+            {
+                FileExtensions = new List<string> { ".txt" },
+                Directories = new List<string> { _testDirectory },
+                FileNames = new List<string> { "test.txt" }
+            };
+
+            fileWatcherService.ConfigureEventFiltering(filterOptions);
+
+            var testFilePath = Path.Combine(_testDirectory, "test.txt");
+            File.WriteAllText(testFilePath, "Test content");
+
+            fileWatcherService.StartWatching(_testDirectory);
+
+            var metadata = fileWatcherService.GetFileMetadata(testFilePath);
+
+            Assert.Equal(testFilePath, metadata.Path);
+            Assert.Equal("Test content".Length, metadata.Size);
+            Assert.Equal(File.GetLastWriteTimeUtc(testFilePath), metadata.LastModified);
+            Assert.Equal(File.GetCreationTimeUtc(testFilePath), metadata.CreatedAt);
+            Assert.Equal(FileAttributes.Normal, metadata.Attributes);
+            Assert.Equal("Unknown", metadata.User);
+            Assert.Equal("Unknown", metadata.Process);
+            Assert.Equal(DateTime.UtcNow.Date, metadata.Timestamp.Date);
+
+            fileWatcherService.StopWatching();
+        }
+    }
+}

--- a/FileSnap.Tests/FileWatcherServiceTests.cs
+++ b/FileSnap.Tests/FileWatcherServiceTests.cs
@@ -1,177 +1,172 @@
 using FileSnap.Core.Services;
-using FileSnap.Core.Models;
 using Moq;
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Runtime.InteropServices;
-using Xunit;
 
-namespace FileSnap.Tests
+namespace FileSnap.Tests;
+
+public class FileWatcherServiceTests
 {
-    public class FileWatcherServiceTests
+    private readonly Mock<IFileWatcherService> _fileWatcherServiceMock;
+    private readonly string _testDirectory;
+
+    public FileWatcherServiceTests()
     {
-        private readonly Mock<IFileWatcherService> _fileWatcherServiceMock;
-        private readonly string _testDirectory;
+        _fileWatcherServiceMock = new Mock<IFileWatcherService>();
+        _testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        Directory.CreateDirectory(_testDirectory);
+    }
 
-        public FileWatcherServiceTests()
+    [Fact]
+    public void StartWatching_ShouldStartWatcher()
+    {
+        _fileWatcherServiceMock.Object.StartWatching(_testDirectory);
+        _fileWatcherServiceMock.Verify(service => service.StartWatching(_testDirectory), Times.Once);
+    }
+
+    [Fact]
+    public void StopWatching_ShouldStopWatcher()
+    {
+        _fileWatcherServiceMock.Object.StopWatching();
+        _fileWatcherServiceMock.Verify(service => service.StopWatching(), Times.Once);
+    }
+
+    [Fact]
+    public void ConfigureFilePermissionChanges_ShouldSetOption()
+    {
+        _fileWatcherServiceMock.Object.ConfigureFilePermissionChanges(true);
+        _fileWatcherServiceMock.Verify(service => service.ConfigureFilePermissionChanges(true), Times.Once);
+    }
+
+    [Fact]
+    public void ConfigureSymbolicLinks_ShouldSetOption()
+    {
+        _fileWatcherServiceMock.Object.ConfigureSymbolicLinks(true);
+        _fileWatcherServiceMock.Verify(service => service.ConfigureSymbolicLinks(true), Times.Once);
+    }
+
+    [Fact]
+    public void ConfigureFileRenames_ShouldSetOption()
+    {
+        _fileWatcherServiceMock.Object.ConfigureFileRenames(true);
+        _fileWatcherServiceMock.Verify(service => service.ConfigureFileRenames(true), Times.Once);
+    }
+
+    [Fact]
+    public void ConfigureFileDeletions_ShouldSetOption()
+    {
+        _fileWatcherServiceMock.Object.ConfigureFileDeletions(true);
+        _fileWatcherServiceMock.Verify(service => service.ConfigureFileDeletions(true), Times.Once);
+    }
+
+    [Fact]
+    public void ConfigureFileMoves_ShouldSetOption()
+    {
+        _fileWatcherServiceMock.Object.ConfigureFileMoves(true);
+        _fileWatcherServiceMock.Verify(service => service.ConfigureFileMoves(true), Times.Once);
+    }
+
+    [Fact]
+    public void ConfigureFileAttributeChanges_ShouldSetOption()
+    {
+        _fileWatcherServiceMock.Object.ConfigureFileAttributeChanges(true);
+        _fileWatcherServiceMock.Verify(service => service.ConfigureFileAttributeChanges(true), Times.Once);
+    }
+
+    [Fact]
+    public void ConfigureFileCreationEvents_ShouldSetOption()
+    {
+        _fileWatcherServiceMock.Object.ConfigureFileCreationEvents(true);
+        _fileWatcherServiceMock.Verify(service => service.ConfigureFileCreationEvents(true), Times.Once);
+    }
+
+    [Fact]
+    public void ConfigureFileModifications_ShouldSetOption()
+    {
+        _fileWatcherServiceMock.Object.ConfigureFileModifications(true);
+        _fileWatcherServiceMock.Verify(service => service.ConfigureFileModifications(true), Times.Once);
+    }
+
+    [Fact]
+    public void ConfigureEventFiltering_ShouldSetFilterOptions()
+    {
+        var filterOptions = new EventFilterOptions
         {
-            _fileWatcherServiceMock = new Mock<IFileWatcherService>();
-            _testDirectory = Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
-            Directory.CreateDirectory(_testDirectory);
-        }
+            FileExtensions = new List<string> { ".txt" },
+            Directories = new List<string> { _testDirectory },
+            FileNames = new List<string> { "test.txt" }
+        };
 
-        [Fact]
-        public void StartWatching_ShouldStartWatcher()
+        _fileWatcherServiceMock.Object.ConfigureEventFiltering(filterOptions);
+        _fileWatcherServiceMock.Verify(service => service.ConfigureEventFiltering(filterOptions), Times.Once);
+    }
+
+    [Fact]
+    public void FileWatcher_ShouldCaptureMetadata()
+    {
+        var fileWatcherService = new FileWatcherService();
+        var testFilePath = Path.Combine(_testDirectory, "test.txt");
+        File.WriteAllText(testFilePath, "Test content");
+        File.SetAttributes(testFilePath, FileAttributes.Normal);
+
+        fileWatcherService.StartWatching(_testDirectory);
+
+        var metadata = fileWatcherService.GetFileMetadata(testFilePath);
+
+        Assert.Equal(testFilePath, metadata.Path);
+        Assert.Equal("Test content".Length, metadata.Size);
+        Assert.Equal(File.GetLastWriteTimeUtc(testFilePath), metadata.LastModified);
+        Assert.Equal(File.GetCreationTimeUtc(testFilePath), metadata.CreatedAt);
+        Assert.Equal(FileAttributes.Normal, metadata.Attributes);
+        Assert.Equal("Unknown", metadata.User);
+        Assert.Equal("Unknown", metadata.Process);
+        Assert.Equal(DateTime.UtcNow.Date, metadata.Timestamp.Date);
+
+        fileWatcherService.StopWatching();
+    }
+
+    [Fact]
+    public void ConfigureFileSystemMountEvents_ShouldSetOption()
+    {
+        _fileWatcherServiceMock.Object.ConfigureFileSystemMountEvents(true);
+        _fileWatcherServiceMock.Verify(service => service.ConfigureFileSystemMountEvents(true), Times.Once);
+    }
+
+    [Fact]
+    public void ConfigureNetworkFileSystems_ShouldSetOption()
+    {
+        _fileWatcherServiceMock.Object.ConfigureNetworkFileSystems(true);
+        _fileWatcherServiceMock.Verify(service => service.ConfigureNetworkFileSystems(true), Times.Once);
+    }
+
+    [Fact]
+    public void FileWatcher_ShouldFilterEvents()
+    {
+        var fileWatcherService = new FileWatcherService();
+        var filterOptions = new EventFilterOptions
         {
-            _fileWatcherServiceMock.Object.StartWatching(_testDirectory);
-            _fileWatcherServiceMock.Verify(service => service.StartWatching(_testDirectory), Times.Once);
-        }
+            FileExtensions = [".txt"],
+            Directories = [_testDirectory],
+            FileNames = ["test.txt"]
+        };
 
-        [Fact]
-        public void StopWatching_ShouldStopWatcher()
-        {
-            _fileWatcherServiceMock.Object.StopWatching();
-            _fileWatcherServiceMock.Verify(service => service.StopWatching(), Times.Once);
-        }
+        fileWatcherService.ConfigureEventFiltering(filterOptions);
 
-        [Fact]
-        public void ConfigureFilePermissionChanges_ShouldSetOption()
-        {
-            _fileWatcherServiceMock.Object.ConfigureFilePermissionChanges(true);
-            _fileWatcherServiceMock.Verify(service => service.ConfigureFilePermissionChanges(true), Times.Once);
-        }
+        var testFilePath = Path.Combine(_testDirectory, "test.txt");
+        File.WriteAllText(testFilePath, "Test content");
+        File.SetAttributes(testFilePath, FileAttributes.Normal);
 
-        [Fact]
-        public void ConfigureSymbolicLinks_ShouldSetOption()
-        {
-            _fileWatcherServiceMock.Object.ConfigureSymbolicLinks(true);
-            _fileWatcherServiceMock.Verify(service => service.ConfigureSymbolicLinks(true), Times.Once);
-        }
+        fileWatcherService.StartWatching(_testDirectory);
 
-        [Fact]
-        public void ConfigureFileRenames_ShouldSetOption()
-        {
-            _fileWatcherServiceMock.Object.ConfigureFileRenames(true);
-            _fileWatcherServiceMock.Verify(service => service.ConfigureFileRenames(true), Times.Once);
-        }
+        var metadata = fileWatcherService.GetFileMetadata(testFilePath);
 
-        [Fact]
-        public void ConfigureFileDeletions_ShouldSetOption()
-        {
-            _fileWatcherServiceMock.Object.ConfigureFileDeletions(true);
-            _fileWatcherServiceMock.Verify(service => service.ConfigureFileDeletions(true), Times.Once);
-        }
+        Assert.Equal(testFilePath, metadata.Path);
+        Assert.Equal("Test content".Length, metadata.Size);
+        Assert.Equal(File.GetLastWriteTimeUtc(testFilePath), metadata.LastModified);
+        Assert.Equal(File.GetCreationTimeUtc(testFilePath), metadata.CreatedAt);
+        Assert.Equal(FileAttributes.Normal, metadata.Attributes);
+        Assert.Equal("Unknown", metadata.User);
+        Assert.Equal("Unknown", metadata.Process);
+        Assert.Equal(DateTime.UtcNow.Date, metadata.Timestamp.Date);
 
-        [Fact]
-        public void ConfigureFileMoves_ShouldSetOption()
-        {
-            _fileWatcherServiceMock.Object.ConfigureFileMoves(true);
-            _fileWatcherServiceMock.Verify(service => service.ConfigureFileMoves(true), Times.Once);
-        }
-
-        [Fact]
-        public void ConfigureFileAttributeChanges_ShouldSetOption()
-        {
-            _fileWatcherServiceMock.Object.ConfigureFileAttributeChanges(true);
-            _fileWatcherServiceMock.Verify(service => service.ConfigureFileAttributeChanges(true), Times.Once);
-        }
-
-        [Fact]
-        public void ConfigureFileCreationEvents_ShouldSetOption()
-        {
-            _fileWatcherServiceMock.Object.ConfigureFileCreationEvents(true);
-            _fileWatcherServiceMock.Verify(service => service.ConfigureFileCreationEvents(true), Times.Once);
-        }
-
-        [Fact]
-        public void ConfigureFileModifications_ShouldSetOption()
-        {
-            _fileWatcherServiceMock.Object.ConfigureFileModifications(true);
-            _fileWatcherServiceMock.Verify(service => service.ConfigureFileModifications(true), Times.Once);
-        }
-
-        [Fact]
-        public void ConfigureEventFiltering_ShouldSetFilterOptions()
-        {
-            var filterOptions = new EventFilterOptions
-            {
-                FileExtensions = new List<string> { ".txt" },
-                Directories = new List<string> { _testDirectory },
-                FileNames = new List<string> { "test.txt" }
-            };
-
-            _fileWatcherServiceMock.Object.ConfigureEventFiltering(filterOptions);
-            _fileWatcherServiceMock.Verify(service => service.ConfigureEventFiltering(filterOptions), Times.Once);
-        }
-
-        [Fact]
-        public void FileWatcher_ShouldCaptureMetadata()
-        {
-            var fileWatcherService = new FileWatcherService();
-            var testFilePath = Path.Combine(_testDirectory, "test.txt");
-            File.WriteAllText(testFilePath, "Test content");
-
-            fileWatcherService.StartWatching(_testDirectory);
-
-            var metadata = fileWatcherService.GetFileMetadata(testFilePath);
-
-            Assert.Equal(testFilePath, metadata.Path);
-            Assert.Equal("Test content".Length, metadata.Size);
-            Assert.Equal(File.GetLastWriteTimeUtc(testFilePath), metadata.LastModified);
-            Assert.Equal(File.GetCreationTimeUtc(testFilePath), metadata.CreatedAt);
-            Assert.Equal(FileAttributes.Normal, metadata.Attributes);
-            Assert.Equal("Unknown", metadata.User);
-            Assert.Equal("Unknown", metadata.Process);
-            Assert.Equal(DateTime.UtcNow.Date, metadata.Timestamp.Date);
-
-            fileWatcherService.StopWatching();
-        }
-
-        [Fact]
-        public void ConfigureFileSystemMountEvents_ShouldSetOption()
-        {
-            _fileWatcherServiceMock.Object.ConfigureFileSystemMountEvents(true);
-            _fileWatcherServiceMock.Verify(service => service.ConfigureFileSystemMountEvents(true), Times.Once);
-        }
-
-        [Fact]
-        public void ConfigureNetworkFileSystems_ShouldSetOption()
-        {
-            _fileWatcherServiceMock.Object.ConfigureNetworkFileSystems(true);
-            _fileWatcherServiceMock.Verify(service => service.ConfigureNetworkFileSystems(true), Times.Once);
-        }
-
-        [Fact]
-        public void FileWatcher_ShouldFilterEvents()
-        {
-            var fileWatcherService = new FileWatcherService();
-            var filterOptions = new EventFilterOptions
-            {
-                FileExtensions = new List<string> { ".txt" },
-                Directories = new List<string> { _testDirectory },
-                FileNames = new List<string> { "test.txt" }
-            };
-
-            fileWatcherService.ConfigureEventFiltering(filterOptions);
-
-            var testFilePath = Path.Combine(_testDirectory, "test.txt");
-            File.WriteAllText(testFilePath, "Test content");
-
-            fileWatcherService.StartWatching(_testDirectory);
-
-            var metadata = fileWatcherService.GetFileMetadata(testFilePath);
-
-            Assert.Equal(testFilePath, metadata.Path);
-            Assert.Equal("Test content".Length, metadata.Size);
-            Assert.Equal(File.GetLastWriteTimeUtc(testFilePath), metadata.LastModified);
-            Assert.Equal(File.GetCreationTimeUtc(testFilePath), metadata.CreatedAt);
-            Assert.Equal(FileAttributes.Normal, metadata.Attributes);
-            Assert.Equal("Unknown", metadata.User);
-            Assert.Equal("Unknown", metadata.Process);
-            Assert.Equal(DateTime.UtcNow.Date, metadata.Timestamp.Date);
-
-            fileWatcherService.StopWatching();
-        }
+        fileWatcherService.StopWatching();
     }
 }

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - **Restore Snapshots**: Restore file system states to a previous snapshot, including file content and metadata.
 - **Optimized Storage**: Uses compression to minimize storage space for snapshots.
 - **Cross-Platform**: Compatible with Windows, macOS, and Linux.
+- **Real-time Monitoring**: Monitor file system changes in real-time using platform-specific APIs (ReadDirectoryChangesW on Windows, SFEvents on MacOS, and inotify on Linux).
 
 ## Installation
 
@@ -285,6 +286,77 @@ class Program
 ```
 
 This example demonstrates how to use FileSnap to implement a simple backup and restore system, including capturing, comparing, and restoring file system snapshots, with incremental snapshots.
+
+### Real-time File System Monitoring
+
+FileSnap also provides real-time file system monitoring using platform-specific APIs (ReadDirectoryChangesW on Windows, SFEvents on MacOS, and inotify on Linux). You can configure the file watcher to handle various file events and filter events based on your preferences.
+
+#### Starting and Stopping the File Watcher
+
+```csharp
+using FileSnap.Core.Services;
+
+var snapshotService = new SnapshotService(new HashingService());
+
+// Start watching a directory for file system changes
+snapshotService.StartFileWatcher("path/to/directory");
+
+// Stop watching the directory
+snapshotService.StopFileWatcher();
+```
+
+#### Configuring File Event Handling
+
+You can configure the file watcher to handle various file events, such as file permission changes, symbolic links, file renames, file deletions, file moves, file attribute changes, file creation events, and file modifications.
+
+```csharp
+using FileSnap.Core.Services;
+
+var fileWatcherService = new FileWatcherService();
+
+// Configure file permission changes
+fileWatcherService.ConfigureFilePermissionChanges(true);
+
+// Configure symbolic links
+fileWatcherService.ConfigureSymbolicLinks(true);
+
+// Configure file renames
+fileWatcherService.ConfigureFileRenames(true);
+
+// Configure file deletions
+fileWatcherService.ConfigureFileDeletions(true);
+
+// Configure file moves
+fileWatcherService.ConfigureFileMoves(true);
+
+// Configure file attribute changes
+fileWatcherService.ConfigureFileAttributeChanges(true);
+
+// Configure file creation events
+fileWatcherService.ConfigureFileCreationEvents(true);
+
+// Configure file modifications
+fileWatcherService.ConfigureFileModifications(true);
+```
+
+#### Configuring Event Filtering
+
+You can filter file events based on file extensions, directories, or specific file names.
+
+```csharp
+using FileSnap.Core.Services;
+
+var fileWatcherService = new FileWatcherService();
+
+var filterOptions = new EventFilterOptions
+{
+    FileExtensions = new List<string> { ".txt" },
+    Directories = new List<string> { "path/to/directory" },
+    FileNames = new List<string> { "test.txt" }
+};
+
+fileWatcherService.ConfigureEventFiltering(filterOptions);
+```
 
 ## Using the Graphical Interface
 


### PR DESCRIPTION
Add real-time file system monitoring to the FileSnap library.

* **FileWatcherService**: Add `FileWatcherService` class to monitor file system changes in real-time using platform-specific APIs (ReadDirectoryChangesW on Windows, SFEvents on MacOS, and inotify on Linux). Implement methods for starting and stopping the watcher, configuring event handling options, and filtering events.
* **FileMetadata and DirectoryMetadata**: Add `User`, `Process`, and `Timestamp` properties to `FileMetadata` and `DirectoryMetadata` classes. Update constructors to initialize new properties.
* **IFileWatcherService**: Define `IFileWatcherService` interface with methods for starting and stopping the watcher, configuring event handling options, and filtering events.
* **SnapshotService**: Integrate `FileWatcherService` into `SnapshotService`. Add methods for starting and stopping the file watcher.
* **Unit Tests**: Add unit tests for `FileWatcherService` in `FileSnap.Tests/FileWatcherServiceTests.cs`. Verify functionality of platform-specific implementations, event filtering options, and enhanced event metadata.
* **Documentation**: Update `README.md` to include usage instructions for the new file watcher feature.

